### PR TITLE
xml2xhtml.xsl: add UTF8 encoding

### DIFF
--- a/data/c++.m4
+++ b/data/c++.m4
@@ -226,7 +226,7 @@ m4_define([b4_symbol_type_declare],
 [[    /// A complete symbol.
     ///
     /// Expects its Base type to provide access to the symbol type
-    /// via type_get().
+    /// via type_get ().
     ///
     /// Provide access to semantic value]b4_locations_if([ and location])[.
     template <typename Base>

--- a/data/lalr1.cc
+++ b/data/lalr1.cc
@@ -89,7 +89,7 @@ m4_define([_b4_rhs_value],
 
 m4_define([b4_rhs_value],
 [b4_percent_define_ifdef([api.value.automove],
-                         [YY_MOVE(_b4_rhs_value($@))],
+                         [YY_MOVE (_b4_rhs_value($@))],
                          [_b4_rhs_value($@)])])
 
 
@@ -672,7 +672,7 @@ m4_if(b4_prefix, [yy], [],
 #if defined __cplusplus && 201103L <= __cplusplus
     yypush_ (m, stack_symbol_type (s, YY_MOVE (sym)));
 #else
-    stack_symbol_type ss(s, sym);
+    stack_symbol_type ss (s, sym);
     yypush_ (m, ss);
 #endif
   }

--- a/data/location.cc
+++ b/data/location.cc
@@ -114,10 +114,11 @@ m4_define([b4_location_define],
     unsigned column;
 
   private:
-    /// Compute max(min, lhs+rhs).
+    /// Compute max (min, lhs+rhs).
     static unsigned add_ (unsigned lhs, int rhs, int min)
     {
-      return static_cast<unsigned>(std::max(min, static_cast<int>(lhs) + rhs));
+      return static_cast<unsigned> (std::max (min,
+                                              static_cast<int> (lhs) + rhs));
     }
   };
 

--- a/data/stack.hh
+++ b/data/stack.hh
@@ -73,7 +73,7 @@ m4_define([b4_stack_define],
     void
     push (YY_MOVE_REF (T) t)
     {
-      seq_.push_back (T());
+      seq_.push_back (T ());
       operator[](0).move (t);
     }
 

--- a/data/variant.hh
+++ b/data/variant.hh
@@ -55,15 +55,15 @@ dummy[]_b4_char_sizeof_counter])
 # ---------------------------
 # To be mapped on the list of type names to produce:
 #
-#    char dummy1[sizeof(type_name_1)];
-#    char dummy2[sizeof(type_name_2)];
+#    char dummy1[sizeof (type_name_1)];
+#    char dummy2[sizeof (type_name_2)];
 #
 # for defined type names.
 m4_define([b4_char_sizeof],
 [b4_symbol_if([$1], [has_type],
 [
 m4_map([      b4_symbol_tag_comment], [$@])dnl
-      char _b4_char_sizeof_dummy@{sizeof(b4_symbol([$1], [type]))@};
+      char _b4_char_sizeof_dummy@{sizeof (b4_symbol([$1], [type]))@};
 ])])
 
 
@@ -222,7 +222,7 @@ m4_define([b4_variant_define],
 
   private:
     /// Prohibit blind copies.
-    self_type& operator=(const self_type&);
+    self_type& operator= (const self_type&);
     variant (const self_type&);
 
     /// Accessor to raw memory as \a T.
@@ -271,7 +271,7 @@ m4_define([b4_value_type_declare],
     {]b4_type_foreach([b4_char_sizeof])[};
 
     /// Symbol semantic values.
-    typedef variant<sizeof(union_type)> semantic_type;][]dnl
+    typedef variant<sizeof (union_type)> semantic_type;][]dnl
 ])
 
 

--- a/data/xslt/xml2xhtml.xsl
+++ b/data/xslt/xml2xhtml.xsl
@@ -38,6 +38,7 @@
 <xsl:template match="/">
   <html>
     <head>
+      <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
       <title>
         <xsl:value-of select="bison-xml-report/filename"/>
         <xsl:text> - GNU Bison XML Automaton Report</xsl:text>

--- a/examples/variant-11.yy
+++ b/examples/variant-11.yy
@@ -66,7 +66,7 @@
   make_string_uptr (Args&&... args)
   {
     // std::make_unique is C++14.
-    return std::unique_ptr<std::string>(new std::string{std::forward<Args>(args)...});
+    return string_uptr (new std::string{std::forward<Args> (args)...});
   }
 
   // Convert to string.

--- a/examples/variant-11.yy
+++ b/examples/variant-11.yy
@@ -101,7 +101,7 @@ list:
 ;
 
 item:
-  TEXT    { $$ = $1; }
+  TEXT
 | NUMBER  { $$ = make_string_uptr (to_string ($1)); }
 ;
 %%

--- a/examples/variant.yy
+++ b/examples/variant.yy
@@ -48,7 +48,7 @@ typedef std::vector<std::string> strings_type;
     {
       o << '{';
       const char *sep = "";
-      for (strings_type::const_iterator i = ss.begin(), end = ss.end();
+      for (strings_type::const_iterator i = ss.begin (), end = ss.end ();
            i != end; ++i)
         {
           o << sep << *i;
@@ -110,7 +110,7 @@ namespace yy
   {
     static int stage = -1;
     ++stage;
-    parser::location_type loc(YY_NULLPTR, stage + 1, stage + 1);
+    parser::location_type loc (YY_NULLPTR, stage + 1, stage + 1);
     switch (stage)
       {
       case 0:

--- a/examples/variant.yy
+++ b/examples/variant.yy
@@ -89,7 +89,7 @@ list:
 ;
 
 item:
-  TEXT    { std::swap ($$, $1); }
+  TEXT
 | NUMBER  { $$ = to_string ($1); }
 ;
 %%

--- a/src/reader.c
+++ b/src/reader.c
@@ -576,32 +576,18 @@ packgram (void)
 
   for (symbol_list *p = grammar; p; p = p->next)
     {
-      symbol *ruleprec = p->ruleprec;
-      record_merge_function_type (p->merger, p->content.sym->content->type_name,
-                                  p->merger_declaration_location);
-      rules[ruleno].user_number = ruleno;
-      rules[ruleno].number = ruleno;
-      rules[ruleno].lhs = p->content.sym->content;
-      rules[ruleno].rhs = ritem + itemno;
-      rules[ruleno].prec = NULL;
-      rules[ruleno].dprec = p->dprec;
-      rules[ruleno].merger = p->merger;
-      rules[ruleno].precsym = NULL;
-      rules[ruleno].location = p->location;
-      rules[ruleno].useful = true;
-      rules[ruleno].action = p->action_props.code;
-      rules[ruleno].action_location = p->action_props.location;
-      rules[ruleno].is_predicate = p->action_props.is_predicate;
-
+      symbol_list *lhs = p;
+      record_merge_function_type (lhs->merger, lhs->content.sym->content->type_name,
+                                  lhs->merger_declaration_location);
       /* If the midrule's $$ is set or its $n is used, remove the '$' from the
          symbol name so that it's a user-defined symbol so that the default
          %destructor and %printer apply.  */
-      if (p->midrule_parent_rule
-          && (p->action_props.is_value_used
-              || (symbol_list_n_get (p->midrule_parent_rule,
-                                     p->midrule_parent_rhs_index)
+      if (lhs->midrule_parent_rule
+          && (lhs->action_props.is_value_used
+              || (symbol_list_n_get (lhs->midrule_parent_rule,
+                                     lhs->midrule_parent_rhs_index)
                   ->action_props.is_value_used)))
-        p->content.sym->tag += 1;
+        lhs->content.sym->tag += 1;
 
       /* Don't check the generated rule 0.  It has no action, so some rhs
          symbols may appear unused, but the parsing algorithm ensures that
@@ -609,6 +595,21 @@ packgram (void)
       if (p != grammar)
         grammar_rule_check (p);
 
+      rules[ruleno].user_number = ruleno;
+      rules[ruleno].number = ruleno;
+      rules[ruleno].lhs = lhs->content.sym->content;
+      rules[ruleno].rhs = ritem + itemno;
+      rules[ruleno].prec = NULL;
+      rules[ruleno].dprec = lhs->dprec;
+      rules[ruleno].merger = lhs->merger;
+      rules[ruleno].precsym = NULL;
+      rules[ruleno].location = lhs->location;
+      rules[ruleno].useful = true;
+      rules[ruleno].action = lhs->action_props.code;
+      rules[ruleno].action_location = lhs->action_props.location;
+      rules[ruleno].is_predicate = lhs->action_props.is_predicate;
+
+      /* Traverse the rhs.  */
       {
         size_t rule_length = 0;
         for (p = p->next; p->content.sym; p = p->next)
@@ -633,11 +634,12 @@ packgram (void)
 
       /* If this rule has a %prec,
          the specified symbol's precedence replaces the default.  */
-      if (ruleprec)
+      if (lhs->ruleprec)
         {
-          rules[ruleno].precsym = ruleprec->content;
-          rules[ruleno].prec = ruleprec->content;
+          rules[ruleno].precsym = lhs->ruleprec->content;
+          rules[ruleno].prec = lhs->ruleprec->content;
         }
+
       /* An item ends by the rule number (negated).  */
       ritem[itemno++] = rule_number_as_item_number (ruleno);
       aver (itemno < ITEM_NUMBER_MAX);

--- a/src/reader.c
+++ b/src/reader.c
@@ -275,13 +275,14 @@ symbol_should_be_used (symbol_list const *s, bool *midrule_warning)
   return false;
 }
 
-/*----------------------------------------------------------------.
-| Check that the rule R is properly defined.  For instance, there |
-| should be no type clash on the default action.                  |
-`----------------------------------------------------------------*/
+/*-----------------------------------------------------------------.
+| Check that the rule R is properly defined.  For instance, there  |
+| should be no type clash on the default action.  Possibly install |
+| the default action.                                              |
+`-----------------------------------------------------------------*/
 
 static void
-grammar_rule_check (const symbol_list *r)
+grammar_rule_check_and_complete (symbol_list *r)
 {
   /* Type check.
 
@@ -303,6 +304,16 @@ grammar_rule_check (const symbol_list *r)
             complain (&r->location, Wother,
                       _("type clash on default action: <%s> != <%s>"),
                       lhs_type, rhs_type);
+          else
+            {
+              /* Install the default action.  */
+              code_props_rule_action_init (&r->action_props, "{ $$ = $1; }",
+                                           r->location, r,
+                                           /* name */ NULL,
+                                           /* type */ NULL,
+                                           /* is_predicate */ false);
+              code_props_translate_code (&r->action_props);
+            }
         }
       /* Warn if there is no default for $$ but we need one.  */
       else
@@ -439,14 +450,14 @@ grammar_current_rule_prec_set (symbol *precsym, location loc)
 {
   /* POSIX says that any identifier is a nonterminal if it does not
      appear on the LHS of a grammar rule and is not defined by %token
-     or by one of the directives that assigns precedence to a token.  We
-     ignore this here because the only kind of identifier that POSIX
-     allows to follow a %prec is a token and because assuming it's a
-     token now can produce more logical error messages.  Nevertheless,
-     grammar_rule_check does obey what we believe is the real intent of
-     POSIX here: that an error be reported for any identifier that
-     appears after %prec but that is not defined separately as a
-     token.  */
+     or by one of the directives that assigns precedence to a token.
+     We ignore this here because the only kind of identifier that
+     POSIX allows to follow a %prec is a token and because assuming
+     it's a token now can produce more logical error messages.
+     Nevertheless, grammar_rule_check_and_complete does obey what we
+     believe is the real intent of POSIX here: that an error be
+     reported for any identifier that appears after %prec but that is
+     not defined separately as a token.  */
   symbol_class_set (precsym, token_sym, loc, false);
   if (current_rule->ruleprec)
     duplicate_directive ("%prec",
@@ -593,7 +604,7 @@ packgram (void)
          symbols may appear unused, but the parsing algorithm ensures that
          %destructor's are invoked appropriately.  */
       if (p != grammar)
-        grammar_rule_check (p);
+        grammar_rule_check_and_complete (p);
 
       rules[ruleno].user_number = ruleno;
       rules[ruleno].number = ruleno;
@@ -799,12 +810,13 @@ check_and_convert_grammar (void)
      symbols_pack above) so that token types are set correctly before the rule
      action type checking.
 
-     Before invoking grammar_rule_check (in packgram below) on any rule, make
-     sure all actions have already been scanned in order to set 'used' flags.
-     Otherwise, checking that a midrule's $$ should be set will not always work
-     properly because the check must forward-reference the midrule's parent
-     rule.  For the same reason, all the 'used' flags must be set before
-     checking whether to remove '$' from any midrule symbol name (also in
+     Before invoking grammar_rule_check_and_complete (in packgram
+     below) on any rule, make sure all actions have already been
+     scanned in order to set 'used' flags.  Otherwise, checking that a
+     midrule's $$ should be set will not always work properly because
+     the check must forward-reference the midrule's parent rule.  For
+     the same reason, all the 'used' flags must be set before checking
+     whether to remove '$' from any midrule symbol name (also in
      packgram).  */
   for (symbol_list *sym = grammar; sym; sym = sym->next)
     code_props_translate_code (&sym->action_props);

--- a/tests/calc.at
+++ b/tests/calc.at
@@ -303,7 +303,7 @@ line:
 ;
 
 exp:
-  NUM                { $$ = $1;             }
+  NUM
 | exp '=' exp
   {
     if ($1 != $3)


### PR DESCRIPTION
... to make arrows appear nicely in the browser. Currently it is shown as some garbled something in mine (Firefox).

@akimd: I am not sure if this is the right place to submit a patch via github, given bison's userlists. It is the easiest here, but please give me a shout if otherwise. Merci beaucoup.