### PR TITLE
Fix gettext segfault

### DIFF
--- a/src/complain.c
+++ b/src/complain.c
@@ -255,7 +255,7 @@ complain_init_color (void)
       || color_mode == color_html
       || (color_mode == color_tty && isatty (STDERR_FILENO)))
     {
-      style_file_prepare ("BISON_STYLE", NULL, pkgdatadir (),
+      style_file_prepare ("BISON_STYLE", "", pkgdatadir (),
                           "bison-default.css");
       /* As a fallback, use the default in the current directory.  */
       struct stat statbuf;


### PR DESCRIPTION
Build of bison `3.4` segfaults, with the following output:

```bash
$ make
<...>
LC_ALL=C tests/bison --version >doc/bison.help.tmp
tests/bison: line 39: 31684 Segmentation fault      (core dumped) $PREBISON "$abs_top_builddir/src/bison" ${1+"$@"} 2> "$stderr"
```

Here is the gdb trace:
```bash
GNU gdb (Ubuntu 8.1-0ubuntu3) 8.1.0.20180409-git
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from $SRC_DIR/src/bison...done.
Starting program: $SRC_DIR/src/bison --color=yes --version

Program received signal SIGSEGV, Segmentation fault.
__strlen_sse2 () at ../sysdeps/x86_64/multiarch/../strlen.S:120
#0  __strlen_sse2 () at ../sysdeps/x86_64/multiarch/../strlen.S:120
#1  0x00007ffff6da0906 in __GI_getenv (name=name@entry=0x0) at getenv.c:35
#2  0x00007ffff7f726ed in style_file_prepare (
    style_file_envvar=style_file_envvar@entry=0x44a5b7 "BISON_STYLE", 
    stylesdir_envvar=stylesdir_envvar@entry=0x0, 
    stylesdir_after_install=0x7fffffffef7b "$SRC_DIR/data", 
    default_style_file=default_style_file@entry=0x44a5a5 "bison-default.css")
    at color.c:437
#3  0x000000000040726c in complain_init_color () at src/complain.c:258
#4  0x000000000040abe5 in getargs_colors (argv=0x7fffffffce88, 
    argv@entry=0x3, argc=3, argc@entry=-12664) at src/getargs.c:612
#5  getargs (argc=argc@entry=3, argv=argv@entry=0x7fffffffce88)
    at src/getargs.c:619
#6  0x00000000004039a4 in main (argc=3, argv=0x7fffffffce88) at src/main.c:90
```

`getenv()` requires a non-null argument.

Build environment:
bison: `3.4`
glibc: `2.29`
gcc `8.3.0`
gettext: `0.20.1`
libiconv: `1.15`
