### PR TITLE
Allow users to customize their error messages

### DIFF
--- a/data/skeletons/bison.m4
+++ b/data/skeletons/bison.m4
@@ -1018,13 +1018,14 @@ m4_define([b4_bison_locations_if],
 
 # b4_error_verbose_if([IF-ERRORS-ARE-VERBOSE], [IF-NOT])
 # ------------------------------------------------------
-# Map %define parse.error "(simple|verbose)" to b4_error_verbose_if and
+# Map %define parse.error "(custom|simple|verbose)" to b4_error_verbose_if and
 # b4_error_verbose_flag.
 b4_percent_define_default([[parse.error]], [[simple]])
 b4_percent_define_check_values([[[[parse.error]],
-                                 [[simple]], [[verbose]]]])
+                                 [[custom]], [[simple]], [[verbose]]]])
 m4_define([b4_error_verbose_flag],
           [m4_case(b4_percent_define_get([[parse.error]]),
+                   [custom],  [[1]],
                    [simple],  [[0]],
                    [verbose], [[1]])])
 b4_define_flag_if([error_verbose])

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -1058,7 +1058,7 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
 
 static int
 yysyntax_error_arguments (const yyparse_context_t *yyctx,
-                          const char *yyarg[], int yyargn)
+                          int yyarg[], int yyargn)
 {
   /* Actual size of YYARG. */
   int yycount = 0;
@@ -1094,7 +1094,7 @@ yysyntax_error_arguments (const yyparse_context_t *yyctx,
     {
       int yyn = yypact[+*yyctx->yyssp];]b4_lac_if([[
       YYDPRINTF ((stderr, "Constructing syntax error message\n"));]])[
-      yyarg[yycount++] = yytname[yyctx->yytoken];
+      yyarg[yycount++] = yyctx->yytoken;
       if (!yypact_value_is_default (yyn))
         {]b4_lac_if([[
           int yyx;
@@ -1126,7 +1126,7 @@ yysyntax_error_arguments (const yyparse_context_t *yyctx,
                     yycount = 1;
                     break;
                   }
-                yyarg[yycount++] = yytname[yyx];
+                yyarg[yycount++] = yyx;
               }
         }]b4_lac_if([[
       else
@@ -1244,7 +1244,7 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
   const char *yyformat = YY_NULLPTR;
   /* Arguments of yyformat: reported tokens (one for the "unexpected",
      one per "expected"). */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
+  int yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
   /* Actual size of YYARG. */
   int yycount = 0;
   /* Cumulated lengths of YYARG.  */
@@ -1283,7 +1283,8 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
     int yyi;
     for (yyi = 0; yyi < yycount; ++yyi)
       {
-        YYPTRDIFF_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yyarg[yyi]);
+        YYPTRDIFF_T yysize1
+          = yysize + yytnamerr (YY_NULLPTR, yytname[yyarg[yyi]]);
         if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
           yysize = yysize1;
         else
@@ -1309,7 +1310,7 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
     while ((*yyp = *yyformat) != '\0')
       if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
         {
-          yyp += yytnamerr (yyp, yyarg[yyi++]);
+          yyp += yytnamerr (yyp, yytname[yyarg[yyi++]]);
           yyformat += 2;
         }
       else

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -1789,25 +1789,26 @@ yyerrlab:
          [simple],
 [[      yyerror (]b4_yyerror_args[YY_("syntax error"));]],
          [verbose],
-[[# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, &yyctx)
-      {
+[[      {
         char const *yymsgp = YY_("syntax error");
         yyparse_context_t yyctx
           = {yyssp, yytoken]b4_lac_if([[, yyesa, &yyes, &yyes_capacity]])[};
         int yysyntax_error_status;]b4_lac_if([[
         if (yychar != YYEMPTY)
           YY_LAC_ESTABLISH;]])[
-        yysyntax_error_status = YYSYNTAX_ERROR;
+        yysyntax_error_status = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
         if (yysyntax_error_status == 0)
           yymsgp = yymsg;
         else if (yysyntax_error_status == 1)
           {
             if (yymsg != yymsgbuf)
               YYSTACK_FREE (yymsg);
-            yymsg = YY_CAST (char *, YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
+            yymsg = YY_CAST (char *,
+                             YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
             if (yymsg)
               {
-                yysyntax_error_status = YYSYNTAX_ERROR;
+                yysyntax_error_status
+                  = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
                 yymsgp = yymsg;
               }
             else
@@ -1820,8 +1821,7 @@ yyerrlab:
         yyerror (]b4_yyerror_args[yymsgp);
         if (yysyntax_error_status == 2)
           goto yyexhaustedlab;
-      }
-# undef YYSYNTAX_ERROR]])[
+      }]])[
     }
 
 ]b4_locations_if([[  yyerror_range[1] = yylloc;]])[

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -1136,7 +1136,11 @@ yysyntax_error_arguments (const yyparse_context_t *yyctx,
 }
 ]])[
 
-]m4_case(b4_percent_define_get([[parse.error]]), [verbose],
+]m4_case(b4_percent_define_get([[parse.error]]),
+         [custom],
+[[static int
+yyreport_syntax_error (const yyparse_context_t *yyctx);]],
+         [verbose],
 [[# ifndef yystrlen
 #  if defined __GLIBC__ && defined _STRING_H
 #   define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
@@ -1786,6 +1790,15 @@ yyerrlab:
     {
       ++yynerrs;
 ]m4_case(b4_percent_define_get([[parse.error]]),
+         [custom],
+[[      {
+        yyparse_context_t yyctx
+          = {yyssp, yytoken]b4_lac_if([[, yyesa, &yyes, &yyes_capacity]])[};]b4_lac_if([[
+        if (yychar != YYEMPTY)
+          YY_LAC_ESTABLISH;]])[
+        if (yyreport_syntax_error (]b4_yyerror_args[&yyctx) == 2)
+          goto yyexhaustedlab;
+      }]],
          [simple],
 [[      yyerror (]b4_yyerror_args[YY_("syntax error"));]],
          [verbose],

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -1046,6 +1046,95 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
     }
 }]])[
 
+]m4_if(b4_percent_define_get([[parse.error]]), [simple], [],
+[[typedef struct
+{
+  yy_state_t *yyssp;
+  int yytoken;]b4_lac_if([[
+  yy_state_t *yyesa;
+  yy_state_t **yyes_p;
+  YYPTRDIFF_T *yyes_capacity_p;]])[
+} yyparse_context_t;
+
+static int
+yysyntax_error_arguments (const yyparse_context_t *yyctx,
+                          const char *yyarg[], int yyargn)
+{
+  /* Actual size of YYARG. */
+  int yycount = 0;
+  /* There are many possibilities here to consider:
+     - If this state is a consistent state with a default action, then
+       the only way this function was invoked is if the default action
+       is an error action.  In that case, don't check for expected
+       tokens because there are none.
+     - The only way there can be no lookahead present (in yychar) is if
+       this state is a consistent state with a default action.  Thus,
+       detecting the absence of a lookahead is sufficient to determine
+       that there is no unexpected or expected token to report.  In that
+       case, just report a simple "syntax error".
+     - Don't assume there isn't a lookahead just because this state is a
+       consistent state with a default action.  There might have been a
+       previous inconsistent state, consistent state with a non-default
+       action, or user semantic action that manipulated yychar.]b4_lac_if([[
+       In the first two cases, it might appear that the current syntax
+       error should have been detected in the previous state when yy_lac
+       was invoked.  However, at that time, there might have been a
+       different syntax error that discarded a different initial context
+       during error recovery, leaving behind the current lookahead.]], [[
+     - Of course, the expected token list depends on states to have
+       correct lookahead information, and it depends on the parser not
+       to perform extra reductions after fetching a lookahead from the
+       scanner and before detecting a syntax error.  Thus, state merging
+       (from LALR or IELR) and default reductions corrupt the expected
+       token list.  However, the list is correct for canonical LR with
+       one exception: it will still contain any token that will not be
+       accepted due to an error action in a later state.]])[
+  */
+  if (yyctx->yytoken != YYEMPTY)
+    {
+      int yyn = yypact[+*yyctx->yyssp];]b4_lac_if([[
+      YYDPRINTF ((stderr, "Constructing syntax error message\n"));]])[
+      yyarg[yycount++] = yytname[yyctx->yytoken];
+      if (!yypact_value_is_default (yyn))
+        {]b4_lac_if([[
+          int yyx;
+          for (yyx = 0; yyx < YYNTOKENS; ++yyx)
+            if (yyx != YYTERROR && yyx != YYUNDEFTOK)
+              {
+                {
+                  int yy_lac_status = yy_lac (yyctx->yyesa, yyctx->yyes_p, yyctx->yyes_capacity_p,
+                                              yyctx->yyssp, yyx);
+                  if (yy_lac_status == 2)
+                    return -2;
+                  if (yy_lac_status == 1)
+                    continue;
+                }]], [[
+          /* Start YYX at -YYN if negative to avoid negative indexes in
+             YYCHECK.  In other words, skip the first -YYN actions for
+             this state because they are default actions.  */
+          int yyxbegin = yyn < 0 ? -yyn : 0;
+          /* Stay within bounds of both yycheck and yytname.  */
+          int yychecklim = YYLAST - yyn + 1;
+          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
+          int yyx;
+          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
+            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
+                && !yytable_value_is_error (yytable[yyx + yyn]))
+              {]])[
+                if (yycount == yyargn)
+                  {
+                    yycount = 1;
+                    break;
+                  }
+                yyarg[yycount++] = yytname[yyx];
+              }
+        }]b4_lac_if([[
+      else
+        YYDPRINTF ((stderr, "No expected tokens.\n"));]])[
+    }
+  return yycount;
+}
+]])[
 
 ]m4_case(b4_percent_define_get([[parse.error]]), [verbose],
 [[# ifndef yystrlen
@@ -1135,6 +1224,7 @@ yytnamerr (char *yyres, const char *yystr)
 }
 # endif
 
+
 /* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
    about the unexpected token YYTOKEN for the state stack whose top is
    YYSSP.]b4_lac_if([[  In order to see if a particular token T is a
@@ -1147,8 +1237,7 @@ yytnamerr (char *yyres, const char *yystr)
    yy_lac returned 2]])[.  */
 static int
 yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
-                ]b4_lac_if([[yy_state_t *yyesa, yy_state_t **yyes,
-                YYPTRDIFF_T *yyes_capacity, ]])[yy_state_t *yyssp, int yytoken)
+                const yyparse_context_t *yyctx)
 {
   enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
   /* Internationalized format string. */
@@ -1161,76 +1250,15 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
   /* Cumulated lengths of YYARG.  */
   YYPTRDIFF_T yysize = 0;
 
-  /* There are many possibilities here to consider:
-     - If this state is a consistent state with a default action, then
-       the only way this function was invoked is if the default action
-       is an error action.  In that case, don't check for expected
-       tokens because there are none.
-     - The only way there can be no lookahead present (in yychar) is if
-       this state is a consistent state with a default action.  Thus,
-       detecting the absence of a lookahead is sufficient to determine
-       that there is no unexpected or expected token to report.  In that
-       case, just report a simple "syntax error".
-     - Don't assume there isn't a lookahead just because this state is a
-       consistent state with a default action.  There might have been a
-       previous inconsistent state, consistent state with a non-default
-       action, or user semantic action that manipulated yychar.]b4_lac_if([[
-       In the first two cases, it might appear that the current syntax
-       error should have been detected in the previous state when yy_lac
-       was invoked.  However, at that time, there might have been a
-       different syntax error that discarded a different initial context
-       during error recovery, leaving behind the current lookahead.]], [[
-     - Of course, the expected token list depends on states to have
-       correct lookahead information, and it depends on the parser not
-       to perform extra reductions after fetching a lookahead from the
-       scanner and before detecting a syntax error.  Thus, state merging
-       (from LALR or IELR) and default reductions corrupt the expected
-       token list.  However, the list is correct for canonical LR with
-       one exception: it will still contain any token that will not be
-       accepted due to an error action in a later state.]])[
-  */
-  if (yytoken != YYEMPTY)
-    {
-      int yyn = yypact[+*yyssp];]b4_lac_if([[
-      YYDPRINTF ((stderr, "Constructing syntax error message\n"));]])[
-      yyarg[yycount++] = yytname[yytoken];
-      if (!yypact_value_is_default (yyn))
-        {]b4_lac_if([[
-          int yyx;
-          for (yyx = 0; yyx < YYNTOKENS; ++yyx)
-            if (yyx != YYTERROR && yyx != YYUNDEFTOK)
-              {
-                {
-                  int yy_lac_status = yy_lac (yyesa, yyes, yyes_capacity,
-                                              yyssp, yyx);
-                  if (yy_lac_status == 2)
-                    return 2;
-                  if (yy_lac_status == 1)
-                    continue;
-                }]], [[
-          /* Start YYX at -YYN if negative to avoid negative indexes in
-             YYCHECK.  In other words, skip the first -YYN actions for
-             this state because they are default actions.  */
-          int yyxbegin = yyn < 0 ? -yyn : 0;
-          /* Stay within bounds of both yycheck and yytname.  */
-          int yychecklim = YYLAST - yyn + 1;
-          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-          int yyx;
-          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
-                && !yytable_value_is_error (yytable[yyx + yyn]))
-              {]])[
-                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-                  {
-                    yycount = 1;
-                    break;
-                  }
-                yyarg[yycount++] = yytname[yyx];
-              }
-        }]b4_lac_if([[
-      else
-        YYDPRINTF ((stderr, "No expected tokens.\n"));]])[
-    }
+  {
+    int yyn
+      = yysyntax_error_arguments (yyctx, yyarg,
+                                  YYSIZEOF (yyarg) / YYSIZEOF (*yyarg));
+    if (yyn == -2)
+      return 2;
+    else
+      yycount = yyn;
+  }
 
   switch (yycount)
     {
@@ -1760,11 +1788,11 @@ yyerrlab:
          [simple],
 [[      yyerror (]b4_yyerror_args[YY_("syntax error"));]],
          [verbose],
-[[# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \]b4_lac_if([[
-                                        yyesa, &yyes, &yyes_capacity, \]])[
-                                        yyssp, yytoken)
+[[# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, &yyctx)
       {
         char const *yymsgp = YY_("syntax error");
+        yyparse_context_t yyctx
+          = {yyssp, yytoken]b4_lac_if([[, yyesa, &yyes, &yyes_capacity]])[};
         int yysyntax_error_status;]b4_lac_if([[
         if (yychar != YYEMPTY)
           YY_LAC_ESTABLISH;]])[

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -1057,10 +1057,10 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
   YYPTRDIFF_T *yyes_capacity_p;]])[
 } yyparse_context_t;
 
-/* Put in YYARG at most YYARGN of the expected tokens given
-   the current YYCTX, and return the number of tokens stored
-   in YYARG.
-   If YYARG is null, return the number of expected tokens.  */
+/* Put in YYARG at most YYARGN of the expected tokens given the
+   current YYCTX, and return the number of tokens stored in YYARG.  If
+   YYARG is null, return the number of expected tokens (guaranteed to
+   be less than YYNTOKENS).  */
 static int
 yyexpected_tokens (const yyparse_context_t *yyctx,
                    int yyarg[], int yyargn)
@@ -1286,20 +1286,14 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
   /* Arguments of yyformat: reported tokens (one for the "unexpected",
      one per "expected"). */
   int yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  /* Actual size of YYARG. */
-  int yycount = 0;
   /* Cumulated lengths of YYARG.  */
   YYPTRDIFF_T yysize = 0;
 
-  {
-    int yyn
-      = yysyntax_error_arguments (yyctx, yyarg,
-                                  YYSIZEOF (yyarg) / YYSIZEOF (*yyarg));
-    if (yyn == -2)
-      return 2;
-    else
-      yycount = yyn;
-  }
+  /* Actual size of YYARG. */
+  int yycount
+    = yysyntax_error_arguments (yyctx, yyarg, YYERROR_VERBOSE_ARGS_MAXIMUM);
+  if (yycount == -2)
+    return 2;
 
   switch (yycount)
     {

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -1174,8 +1174,9 @@ yyparse_context_location (const yyparse_context_t *yyctx)
 }]])[
 
 /* User defined funtion to report a syntax error.  */
-static int
-yyreport_syntax_error (const yyparse_context_t *yyctx);]],
+]b4_function_declare([yyreport_syntax_error], [static int],
+                     [[[const yyparse_context_t *yyctx]], [[yyctx]]],
+                     b4_parse_param)],
          [verbose],
 [[# ifndef yystrlen
 #  if defined __GLIBC__ && defined _STRING_H
@@ -1832,7 +1833,8 @@ yyerrlab:
           = {yyssp, yytoken]b4_locations_if([[, &yylloc]])[]b4_lac_if([[, yyesa, &yyes, &yyes_capacity]])[};]b4_lac_if([[
         if (yychar != YYEMPTY)
           YY_LAC_ESTABLISH;]])[
-        if (yyreport_syntax_error (&yyctx) == 2)
+        if (yyreport_syntax_error (&yyctx]m4_ifset([b4_parse_param],
+                                  [[, ]b4_args(b4_parse_param)])[) == 2)
           goto yyexhaustedlab;
       }]],
          [simple],

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -895,7 +895,7 @@ do {                                                             \
     {                                                            \
       YYDPRINTF ((stderr,                                        \
                   "LAC: initial context established for %s\n",   \
-                  yysymbol_name(yytoken)));                      \
+                  yysymbol_name (yytoken)));                     \
       yy_lac_established = 1;                                    \
       {                                                          \
         int yy_lac_status =                                      \
@@ -948,7 +948,7 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
   yy_state_t *yyes_prev = yyssp;
   yy_state_t *yyesp = yyes_prev;
   /* Reduce until we encounter a shift and thereby accept the token.  */
-  YYDPRINTF ((stderr, "LAC: checking lookahead %s:", yysymbol_name(yytoken)));
+  YYDPRINTF ((stderr, "LAC: checking lookahead %s:", yysymbol_name (yytoken)));
   if (yytoken == YYUNDEFTOK)
     {
       YYDPRINTF ((stderr, " Always Err\n"));
@@ -1056,6 +1056,62 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
   YYPTRDIFF_T *yyes_capacity_p;]])[
 } yyparse_context_t;
 
+/* Put in YYARG at most YYARGN of the expected tokens given
+   the current YYCTX, and return the number of tokens stored
+   in YYARG.
+   If YYARG is null, return the number of expected tokens.  */
+static int
+yyexpected_tokens (const yyparse_context_t *yyctx,
+                   int yyarg[], int yyargn)
+{
+  /* Actual size of YYARG. */
+  int yycount = 0;
+]b4_lac_if([[
+  int yyx;
+  for (yyx = 0; yyx < YYNTOKENS; ++yyx)
+    if (yyx != YYTERROR && yyx != YYUNDEFTOK)
+      {
+        {
+          int yy_lac_status = yy_lac (yyctx->yyesa, yyctx->yyes_p, yyctx->yyes_capacity_p,
+                                      yyctx->yyssp, yyx);
+          if (yy_lac_status == 2)
+            return -2;
+          if (yy_lac_status == 1)
+            continue;
+        }
+        if (!yyarg)
+          ++yycount;
+        else if (yycount == yyargn)
+          return 0;
+        else
+          yyarg[yycount++] = yyx;
+      }]],
+[[  int yyn = yypact[+*yyctx->yyssp];
+  if (!yypact_value_is_default (yyn))
+    {
+      /* Start YYX at -YYN if negative to avoid negative indexes in
+         YYCHECK.  In other words, skip the first -YYN actions for
+         this state because they are default actions.  */
+      int yyxbegin = yyn < 0 ? -yyn : 0;
+      /* Stay within bounds of both yycheck and yytname.  */
+      int yychecklim = YYLAST - yyn + 1;
+      int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
+      int yyx;
+      for (yyx = yyxbegin; yyx < yyxend; ++yyx)
+        if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
+            && !yytable_value_is_error (yytable[yyx + yyn]))
+          {
+            if (!yyarg)
+              ++yycount;
+            else if (yycount == yyargn)
+              return 0;
+            else
+              yyarg[yycount++] = yyx;
+          }
+    }]])[
+  return yycount;
+}
+
 static int
 yysyntax_error_arguments (const yyparse_context_t *yyctx,
                           int yyarg[], int yyargn)
@@ -1092,45 +1148,16 @@ yysyntax_error_arguments (const yyparse_context_t *yyctx,
   */
   if (yyctx->yytoken != YYEMPTY)
     {
-      int yyn = yypact[+*yyctx->yyssp];]b4_lac_if([[
+      int yyn;]b4_lac_if([[
       YYDPRINTF ((stderr, "Constructing syntax error message\n"));]])[
       yyarg[yycount++] = yyctx->yytoken;
-      if (!yypact_value_is_default (yyn))
-        {]b4_lac_if([[
-          int yyx;
-          for (yyx = 0; yyx < YYNTOKENS; ++yyx)
-            if (yyx != YYTERROR && yyx != YYUNDEFTOK)
-              {
-                {
-                  int yy_lac_status = yy_lac (yyctx->yyesa, yyctx->yyes_p, yyctx->yyes_capacity_p,
-                                              yyctx->yyssp, yyx);
-                  if (yy_lac_status == 2)
-                    return -2;
-                  if (yy_lac_status == 1)
-                    continue;
-                }]], [[
-          /* Start YYX at -YYN if negative to avoid negative indexes in
-             YYCHECK.  In other words, skip the first -YYN actions for
-             this state because they are default actions.  */
-          int yyxbegin = yyn < 0 ? -yyn : 0;
-          /* Stay within bounds of both yycheck and yytname.  */
-          int yychecklim = YYLAST - yyn + 1;
-          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-          int yyx;
-          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
-                && !yytable_value_is_error (yytable[yyx + yyn]))
-              {]])[
-                if (yycount == yyargn)
-                  {
-                    yycount = 1;
-                    break;
-                  }
-                yyarg[yycount++] = yyx;
-              }
-        }]b4_lac_if([[
-      else
+      yyn = yyexpected_tokens (yyctx, yyarg ? yyarg + 1 : yyarg, yyargn - 1);
+      if (yyn == -2)
+        return -2;]b4_lac_if([[
+      else if (yyn == 0)
         YYDPRINTF ((stderr, "No expected tokens.\n"));]])[
+      else
+        yycount += yyn;
     }
   return yycount;
 }

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -1050,7 +1050,8 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
 [[typedef struct
 {
   yy_state_t *yyssp;
-  int yytoken;]b4_lac_if([[
+  int yytoken;]b4_locations_if([[
+  YYLTYPE *yylloc;]])[]b4_lac_if([[
   yy_state_t *yyesa;
   yy_state_t **yyes_p;
   YYPTRDIFF_T *yyes_capacity_p;]])[
@@ -1165,7 +1166,15 @@ yysyntax_error_arguments (const yyparse_context_t *yyctx,
 
 ]m4_case(b4_percent_define_get([[parse.error]]),
          [custom],
-[[static int
+[b4_locations_if([[/*  The location of this context.  */
+static YYLTYPE *
+yyparse_context_location (const yyparse_context_t *yyctx)
+{
+  return yyctx->yylloc;
+}]])[
+
+/* User defined funtion to report a syntax error.  */
+static int
 yyreport_syntax_error (const yyparse_context_t *yyctx);]],
          [verbose],
 [[# ifndef yystrlen
@@ -1820,10 +1829,10 @@ yyerrlab:
          [custom],
 [[      {
         yyparse_context_t yyctx
-          = {yyssp, yytoken]b4_lac_if([[, yyesa, &yyes, &yyes_capacity]])[};]b4_lac_if([[
+          = {yyssp, yytoken]b4_locations_if([[, &yylloc]])[]b4_lac_if([[, yyesa, &yyes, &yyes_capacity]])[};]b4_lac_if([[
         if (yychar != YYEMPTY)
           YY_LAC_ESTABLISH;]])[
-        if (yyreport_syntax_error (]b4_yyerror_args[&yyctx) == 2)
+        if (yyreport_syntax_error (&yyctx) == 2)
           goto yyexhaustedlab;
       }]],
          [simple],
@@ -1832,7 +1841,7 @@ yyerrlab:
 [[      {
         char const *yymsgp = YY_("syntax error");
         yyparse_context_t yyctx
-          = {yyssp, yytoken]b4_lac_if([[, yyesa, &yyes, &yyes_capacity]])[};
+          = {yyssp, yytoken]b4_locations_if([[, &yylloc]])[]b4_lac_if([[, yyesa, &yyes, &yyes_capacity]])[};
         int yysyntax_error_status;]b4_lac_if([[
         if (yychar != YYEMPTY)
           YY_LAC_ESTABLISH;]])[

--- a/examples/c/calc/calc.y
+++ b/examples/c/calc/calc.y
@@ -9,6 +9,7 @@
 
 %define api.header.include {"calc.h"}
 %define api.value.type union /* Generate YYSTYPE from these types:  */
+%define parse.error custom
 %token <double> NUM "number"
 %type  <double> expr term fact
 
@@ -50,6 +51,28 @@ fact:
 ;
 
 %%
+
+int
+yyreport_syntax_error (const yyparse_context_t *ctx)
+{
+  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 10 };
+  /* Arguments of yyformat: reported tokens (one for the "unexpected",
+     one per "expected"). */
+  int arg[YYERROR_VERBOSE_ARGS_MAXIMUM];
+  int n = yysyntax_error_arguments (ctx, arg, sizeof arg / sizeof *arg);
+  if (n == -2)
+    return 2;
+  fprintf (stderr, "SYNTAX ERROR on token [%s]", yysymbol_name (arg[0]));
+  if (1 < n)
+    {
+      fprintf (stderr, " (expected:");
+      for (int i = 1; i < n; ++i)
+        fprintf (stderr, " [%s]", yysymbol_name (arg[i]));
+      fprintf (stderr, ")");
+    }
+  fprintf (stderr, "\n");
+  return 0;
+}
 
 int
 yylex (void)

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.5.22-948cd-dirty.  */
+/* A Bison parser, made by GNU Bison 3.5.49-3790-dirty.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
@@ -48,7 +48,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.5.22-948cd-dirty"
+#define YYBISON_VERSION "3.5.49-3790-dirty"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -552,6 +552,15 @@ static const char *const yytname[] =
   "named_ref.opt", "variable", "value", "id", "id_colon", "symbol",
   "string_as_id", "string_as_id.opt", "epilogue.opt", YY_NULLPTR
 };
+
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (int yysymbol) YY_ATTRIBUTE_UNUSED;
+static const char *
+yysymbol_name (int yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
 # ifdef YYPRINT
@@ -794,8 +803,9 @@ static const yytype_int8 yyr2[] =
       }                                                           \
   while (0)
 
-/* Error token number */
+/* Error symbol internal number. */
 #define YYTERROR        1
+/* Error token external number. */
 #define YYERRCODE       256
 
 
@@ -1293,7 +1303,7 @@ do {                                                             \
     {                                                            \
       YYDPRINTF ((stderr,                                        \
                   "LAC: initial context established for %s\n",   \
-                  yytname[yytoken]));                            \
+                  yysymbol_name(yytoken)));                      \
       yy_lac_established = 1;                                    \
       {                                                          \
         int yy_lac_status =                                      \
@@ -1345,7 +1355,8 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
 {
   yy_state_t *yyes_prev = yyssp;
   yy_state_t *yyesp = yyes_prev;
-  YYDPRINTF ((stderr, "LAC: checking lookahead %s:", yytname[yytoken]));
+  /* Reduce until we encounter a shift and thereby accept the token.  */
+  YYDPRINTF ((stderr, "LAC: checking lookahead %s:", yysymbol_name(yytoken)));
   if (yytoken == YYUNDEFTOK)
     {
       YYDPRINTF ((stderr, " Always Err\n"));
@@ -1358,6 +1369,7 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
           || (yyrule += yytoken) < 0 || YYLAST < yyrule
           || yycheck[yyrule] != yytoken)
         {
+          /* Use the default action.  */
           yyrule = yydefact[+*yyesp];
           if (yyrule == 0)
             {
@@ -1367,6 +1379,7 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
         }
       else
         {
+          /* Use the action from yytable.  */
           yyrule = yytable[yyrule];
           if (yytable_value_is_error (yyrule))
             {
@@ -1380,9 +1393,12 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
             }
           yyrule = -yyrule;
         }
+      /* By now we know we have to simulate a reduce.  */
+      YYDPRINTF ((stderr, " R%d", yyrule - 1));
       {
+        /* Pop the corresponding number of values from the stack.  */
         YYPTRDIFF_T yylen = yyr2[yyrule];
-        YYDPRINTF ((stderr, " R%d", yyrule - 1));
+        /* First pop from the LAC stack as many tokens as possible.  */
         if (yyesp != yyes_prev)
           {
             YYPTRDIFF_T yysize = yyesp - *yyes + 1;
@@ -1393,13 +1409,15 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
               }
             else
               {
-                yylen -= yysize;
                 yyesp = yyes_prev;
+                yylen -= yysize;
               }
           }
+        /* Only afterwards look at the main stack.  */
         if (yylen)
           yyesp = yyes_prev -= yylen;
       }
+      /* Push the resulting state of the reduction.  */
       {
         yy_state_fast_t yystate;
         {
@@ -1573,8 +1591,6 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
   if (yytoken != YYEMPTY)
     {
       int yyn = yypact[+*yyssp];
-      YYPTRDIFF_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
-      yysize = yysize0;
       YYDPRINTF ((stderr, "Constructing syntax error message\n"));
       yyarg[yycount++] = yytname[yytoken];
       if (!yypact_value_is_default (yyn))
@@ -1790,8 +1806,10 @@ YYLTYPE yylloc = yyloc_default;
     yy_state_t *yyes;
     YYPTRDIFF_T yyes_capacity;
 
+  /* Whether LAC context is established.  A Boolean.  */
   int yy_lac_established = 0;
   int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
   /* Lookahead token as an internal (translated) token number.  */
   int yytoken = 0;

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -1303,7 +1303,7 @@ do {                                                             \
     {                                                            \
       YYDPRINTF ((stderr,                                        \
                   "LAC: initial context established for %s\n",   \
-                  yysymbol_name(yytoken)));                      \
+                  yysymbol_name (yytoken)));                     \
       yy_lac_established = 1;                                    \
       {                                                          \
         int yy_lac_status =                                      \
@@ -1356,7 +1356,7 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
   yy_state_t *yyes_prev = yyssp;
   yy_state_t *yyesp = yyes_prev;
   /* Reduce until we encounter a shift and thereby accept the token.  */
-  YYDPRINTF ((stderr, "LAC: checking lookahead %s:", yysymbol_name(yytoken)));
+  YYDPRINTF ((stderr, "LAC: checking lookahead %s:", yysymbol_name (yytoken)));
   if (yytoken == YYUNDEFTOK)
     {
       YYDPRINTF ((stderr, " Always Err\n"));
@@ -1454,6 +1454,91 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
     }
 }
 
+typedef struct
+{
+  yy_state_t *yyssp;
+  int yytoken;
+  YYLTYPE *yylloc;
+  yy_state_t *yyesa;
+  yy_state_t **yyes_p;
+  YYPTRDIFF_T *yyes_capacity_p;
+} yyparse_context_t;
+
+/* Put in YYARG at most YYARGN of the expected tokens given the
+   current YYCTX, and return the number of tokens stored in YYARG.  If
+   YYARG is null, return the number of expected tokens (guaranteed to
+   be less than YYNTOKENS).  */
+static int
+yyexpected_tokens (const yyparse_context_t *yyctx,
+                   int yyarg[], int yyargn)
+{
+  /* Actual size of YYARG. */
+  int yycount = 0;
+
+  int yyx;
+  for (yyx = 0; yyx < YYNTOKENS; ++yyx)
+    if (yyx != YYTERROR && yyx != YYUNDEFTOK)
+      {
+        {
+          int yy_lac_status = yy_lac (yyctx->yyesa, yyctx->yyes_p, yyctx->yyes_capacity_p,
+                                      yyctx->yyssp, yyx);
+          if (yy_lac_status == 2)
+            return -2;
+          if (yy_lac_status == 1)
+            continue;
+        }
+        if (!yyarg)
+          ++yycount;
+        else if (yycount == yyargn)
+          return 0;
+        else
+          yyarg[yycount++] = yyx;
+      }
+  return yycount;
+}
+
+static int
+yysyntax_error_arguments (const yyparse_context_t *yyctx,
+                          int yyarg[], int yyargn)
+{
+  /* Actual size of YYARG. */
+  int yycount = 0;
+  /* There are many possibilities here to consider:
+     - If this state is a consistent state with a default action, then
+       the only way this function was invoked is if the default action
+       is an error action.  In that case, don't check for expected
+       tokens because there are none.
+     - The only way there can be no lookahead present (in yychar) is if
+       this state is a consistent state with a default action.  Thus,
+       detecting the absence of a lookahead is sufficient to determine
+       that there is no unexpected or expected token to report.  In that
+       case, just report a simple "syntax error".
+     - Don't assume there isn't a lookahead just because this state is a
+       consistent state with a default action.  There might have been a
+       previous inconsistent state, consistent state with a non-default
+       action, or user semantic action that manipulated yychar.
+       In the first two cases, it might appear that the current syntax
+       error should have been detected in the previous state when yy_lac
+       was invoked.  However, at that time, there might have been a
+       different syntax error that discarded a different initial context
+       during error recovery, leaving behind the current lookahead.
+  */
+  if (yyctx->yytoken != YYEMPTY)
+    {
+      int yyn;
+      YYDPRINTF ((stderr, "Constructing syntax error message\n"));
+      yyarg[yycount++] = yyctx->yytoken;
+      yyn = yyexpected_tokens (yyctx, yyarg ? yyarg + 1 : yyarg, yyargn - 1);
+      if (yyn == -2)
+        return -2;
+      else if (yyn == 0)
+        YYDPRINTF ((stderr, "No expected tokens.\n"));
+      else
+        yycount += yyn;
+    }
+  return yycount;
+}
+
 
 # ifndef yystrlen
 #  if defined __GLIBC__ && defined _STRING_H
@@ -1542,6 +1627,7 @@ yytnamerr (char *yyres, const char *yystr)
 }
 # endif
 
+
 /* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
    about the unexpected token YYTOKEN for the state stack whose top is
    YYSSP.  In order to see if a particular token T is a
@@ -1554,70 +1640,22 @@ yytnamerr (char *yyres, const char *yystr)
    yy_lac returned 2.  */
 static int
 yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
-                yy_state_t *yyesa, yy_state_t **yyes,
-                YYPTRDIFF_T *yyes_capacity, yy_state_t *yyssp, int yytoken)
+                const yyparse_context_t *yyctx)
 {
   enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
   /* Internationalized format string. */
   const char *yyformat = YY_NULLPTR;
   /* Arguments of yyformat: reported tokens (one for the "unexpected",
      one per "expected"). */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  /* Actual size of YYARG. */
-  int yycount = 0;
+  int yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
   /* Cumulated lengths of YYARG.  */
   YYPTRDIFF_T yysize = 0;
 
-  /* There are many possibilities here to consider:
-     - If this state is a consistent state with a default action, then
-       the only way this function was invoked is if the default action
-       is an error action.  In that case, don't check for expected
-       tokens because there are none.
-     - The only way there can be no lookahead present (in yychar) is if
-       this state is a consistent state with a default action.  Thus,
-       detecting the absence of a lookahead is sufficient to determine
-       that there is no unexpected or expected token to report.  In that
-       case, just report a simple "syntax error".
-     - Don't assume there isn't a lookahead just because this state is a
-       consistent state with a default action.  There might have been a
-       previous inconsistent state, consistent state with a non-default
-       action, or user semantic action that manipulated yychar.
-       In the first two cases, it might appear that the current syntax
-       error should have been detected in the previous state when yy_lac
-       was invoked.  However, at that time, there might have been a
-       different syntax error that discarded a different initial context
-       during error recovery, leaving behind the current lookahead.
-  */
-  if (yytoken != YYEMPTY)
-    {
-      int yyn = yypact[+*yyssp];
-      YYDPRINTF ((stderr, "Constructing syntax error message\n"));
-      yyarg[yycount++] = yytname[yytoken];
-      if (!yypact_value_is_default (yyn))
-        {
-          int yyx;
-          for (yyx = 0; yyx < YYNTOKENS; ++yyx)
-            if (yyx != YYTERROR && yyx != YYUNDEFTOK)
-              {
-                {
-                  int yy_lac_status = yy_lac (yyesa, yyes, yyes_capacity,
-                                              yyssp, yyx);
-                  if (yy_lac_status == 2)
-                    return 2;
-                  if (yy_lac_status == 1)
-                    continue;
-                }
-                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-                  {
-                    yycount = 1;
-                    break;
-                  }
-                yyarg[yycount++] = yytname[yyx];
-              }
-        }
-      else
-        YYDPRINTF ((stderr, "No expected tokens.\n"));
-    }
+  /* Actual size of YYARG. */
+  int yycount
+    = yysyntax_error_arguments (yyctx, yyarg, YYERROR_VERBOSE_ARGS_MAXIMUM);
+  if (yycount == -2)
+    return 2;
 
   switch (yycount)
     {
@@ -1642,7 +1680,8 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
     int yyi;
     for (yyi = 0; yyi < yycount; ++yyi)
       {
-        YYPTRDIFF_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yyarg[yyi]);
+        YYPTRDIFF_T yysize1
+          = yysize + yytnamerr (YY_NULLPTR, yytname[yyarg[yyi]]);
         if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
           yysize = yysize1;
         else
@@ -1668,7 +1707,7 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
     while ((*yyp = *yyformat) != '\0')
       if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
         {
-          yyp += yytnamerr (yyp, yyarg[yyi++]);
+          yyp += yytnamerr (yyp, yytname[yyarg[yyi++]]);
           yyformat += 2;
         }
       else
@@ -2640,25 +2679,26 @@ yyerrlab:
   if (!yyerrstatus)
     {
       ++yynerrs;
-# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
-                                        yyesa, &yyes, &yyes_capacity, \
-                                        yyssp, yytoken)
       {
         char const *yymsgp = YY_("syntax error");
+        yyparse_context_t yyctx
+          = {yyssp, yytoken, &yylloc, yyesa, &yyes, &yyes_capacity};
         int yysyntax_error_status;
         if (yychar != YYEMPTY)
           YY_LAC_ESTABLISH;
-        yysyntax_error_status = YYSYNTAX_ERROR;
+        yysyntax_error_status = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
         if (yysyntax_error_status == 0)
           yymsgp = yymsg;
         else if (yysyntax_error_status == 1)
           {
             if (yymsg != yymsgbuf)
               YYSTACK_FREE (yymsg);
-            yymsg = YY_CAST (char *, YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
+            yymsg = YY_CAST (char *,
+                             YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
             if (yymsg)
               {
-                yysyntax_error_status = YYSYNTAX_ERROR;
+                yysyntax_error_status
+                  = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
                 yymsgp = yymsg;
               }
             else
@@ -2672,7 +2712,6 @@ yyerrlab:
         if (yysyntax_error_status == 2)
           goto yyexhaustedlab;
       }
-# undef YYSYNTAX_ERROR
     }
 
   yyerror_range[1] = yylloc;

--- a/src/parse-gram.h
+++ b/src/parse-gram.h
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.5.22-948cd-dirty.  */
+/* A Bison parser, made by GNU Bison 3.5.49-3790-dirty.  */
 
 /* Bison interface for Yacc-like parsers in C
 

--- a/tests/calc.at
+++ b/tests/calc.at
@@ -547,8 +547,7 @@ AT_PARSER_CHECK([calc input], 0, [], [stderr])
 
 # _AT_CHECK_CALC_ERROR($1 = BISON-OPTIONS, $2 = EXIT-STATUS, $3 = INPUT,
 #                      $4 = [NUM-STDERR-LINES],
-#                      $5 = [VERBOSE-AND-LOCATED-ERROR-MESSAGE]
-#                      $6 = [CUSTOM-ERROR-MESSAGE])
+#                      $5 = [CUSTOM-ERROR-MESSAGE])
 # ----------------------------------------------------------------------
 # Run 'calc' on INPUT, and expect a 'syntax error' message.
 #
@@ -556,17 +555,12 @@ AT_PARSER_CHECK([calc input], 0, [], [stderr])
 # otherwise as contents.
 #
 # NUM-STDERR-LINES is the number of expected lines on stderr.
-# Currently this is ignored, though, since the output format is fluctuating.
-#
-# If BISON-OPTIONS contains '%location', then make sure the ERROR-LOCATION
-# is correctly output on stderr.
-#
-# If BISON-OPTIONS contains '%define parse.error verbose', then make sure the
-# IF-YYERROR-VERBOSE message is properly output after 'syntax error, '
-# on STDERR.
-#
 # If BISON-OPTIONS contains '%debug' but not '%glr', then NUM-STDERR-LINES
 # is the number of expected lines on stderr.
+#
+# CUSTOM-ERROR-MESSAGE is the expected error message when parse.error
+# is 'custom' and locations are enabled.  Other expected formats are
+# computed from it.
 m4_define([_AT_CHECK_CALC_ERROR],
 [m4_bmatch([$3], [^/],
            [AT_PARSER_CHECK([calc $3], $2, [], [stderr])],
@@ -596,14 +590,8 @@ sed '/^Starting/d
 mv at-stderr stderr
 
 # 2. Create the reference error message.
-AT_ERROR_CUSTOM_IF([
-  AT_DATA([[expout]],
-[$6
-])
-],
-  [AT_DATA([[expout]],
+AT_DATA([[expout]],
 [$5
-])
 ])
 
 # 3. If locations are not used, remove them.
@@ -611,12 +599,27 @@ AT_YYERROR_SEES_LOC_IF([],
 [[sed 's/^[-0-9.]*: //' expout >at-expout
 mv at-expout expout]])
 
-# 4. If error-verbose is not used, strip the', unexpected....' part.
+# 4. If parse.error is not custom, turn the expected message to
+# the traditional one.
+AT_ERROR_CUSTOM_IF([], [
+AT_PERL_REQUIRE([[-pi -e 'use strict;
+  s{syntax error on token \["?(.*?)"?\] \(expected: (.*)\)}
+  {
+    my $unexp = $][1;
+    my @exps = $][2 =~ /\["?(.*?)"?\]/g;
+    ($][#exps && $][#exps < 4)
+    ? "syntax error, unexpected $unexp, expecting @{[join(\" or \", @exps)]}"
+    : "syntax error, unexpected $unexp";
+  }eg
+' expout]])
+])
+
+# 5. If parse.error is simple, strip the', unexpected....' part.
 AT_ERROR_SIMPLE_IF(
 [[sed 's/syntax error, .*$/syntax error/' expout >at-expout
 mv at-expout expout]])
 
-# 5. Check
+# 6. Actually check.
 AT_CHECK([cat stderr], 0, [expout])
 ])
 
@@ -675,26 +678,20 @@ _AT_CHECK_CALC([$1],
 
 # Some syntax errors.
 _AT_CHECK_CALC_ERROR([$1], [1], [1 2], [15],
-                     [[1.3: syntax error, unexpected number]],
                      [[1.3: syntax error on token ["number"] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] ['\n'])]])
 _AT_CHECK_CALC_ERROR([$1], [1], [1//2], [20],
-                     [[1.3: syntax error, unexpected '/', expecting number or '-' or '(' or '!']],
                      [[1.3: syntax error on token ['/'] (expected: ["number"] ['-'] ['('] ['!'])]])
 _AT_CHECK_CALC_ERROR([$1], [1], [error], [5],
-                     [[1.1: syntax error, unexpected $undefined]],
                      [[1.1: syntax error on token [$undefined] (expected: ["number"] ['-'] ['\n'] ['('] ['!'])]])
 _AT_CHECK_CALC_ERROR([$1], [1], [1 = 2 = 3], [30],
-                     [[1.7: syntax error, unexpected '=']],
                      [[1.7: syntax error on token ['='] (expected: ['-'] ['+'] ['*'] ['/'] ['^'])]])
 _AT_CHECK_CALC_ERROR([$1], [1],
                      [
 +1],
                      [20],
-                     [[2.1: syntax error, unexpected '+']],
                      [[2.1: syntax error on token ['+'] (expected: ["end of input"] ["number"] ['-'] ['\n'] ['('] ['!'])]])
 # Exercise error messages with EOF: work on an empty file.
 _AT_CHECK_CALC_ERROR([$1], [1], [/dev/null], [4],
-                     [[1.1: syntax error, unexpected end of input]],
                      [[1.1: syntax error on token ["end of input"] (expected: ["number"] ['-'] ['\n'] ['('] ['!'])]])
 
 # Exercise the error token: without it, we die at the first error,
@@ -716,11 +713,6 @@ _AT_CHECK_CALC_ERROR([$1], [1], [/dev/null], [4],
 _AT_CHECK_CALC_ERROR([$1], [0],
                      [() + (1 + 1 + 1 +) + (* * *) + (1 * 2 * *) = 1],
                      [250],
-[[1.2: syntax error, unexpected ')', expecting number or '-' or '(' or '!'
-1.18: syntax error, unexpected ')', expecting number or '-' or '(' or '!'
-1.23: syntax error, unexpected '*', expecting number or '-' or '(' or '!'
-1.41: syntax error, unexpected '*', expecting number or '-' or '(' or '!'
-calc: error: 4444 != 1]],
 [[1.2: syntax error on token [')'] (expected: ["number"] ['-'] ['('] ['!'])
 1.18: syntax error on token [')'] (expected: ["number"] ['-'] ['('] ['!'])
 1.23: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
@@ -730,14 +722,9 @@ calc: error: 4444 != 1]])
 # The same, but this time exercising explicitly triggered syntax errors.
 # POSIX says the lookahead causing the error should not be discarded.
 _AT_CHECK_CALC_ERROR([$1], [0], [(!) + (1 2) = 1], [102],
-[[1.10: syntax error, unexpected number
-calc: error: 2222 != 1]],
 [[1.10: syntax error on token ["number"] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] [')'])
 calc: error: 2222 != 1]])
 _AT_CHECK_CALC_ERROR([$1], [0], [(- *) + (1 2) = 1], [113],
-[[1.4: syntax error, unexpected '*', expecting number or '-' or '(' or '!'
-1.12: syntax error, unexpected number
-calc: error: 2222 != 1]],
 [[1.4: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
 1.12: syntax error on token ["number"] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] [')'])
 calc: error: 2222 != 1]])
@@ -745,9 +732,6 @@ calc: error: 2222 != 1]])
 # Check that yyerrok works properly: second error is not reported,
 # third and fourth are.  Parse status is succesful.
 _AT_CHECK_CALC_ERROR([$1], [0], [(* *) + (*) + (*)], [113],
-[[1.2: syntax error, unexpected '*', expecting number or '-' or '(' or '!'
-1.10: syntax error, unexpected '*', expecting number or '-' or '(' or '!'
-1.16: syntax error, unexpected '*', expecting number or '-' or '(' or '!']],
 [[1.2: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
 1.10: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
 1.16: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])]])

--- a/tests/calc.at
+++ b/tests/calc.at
@@ -34,9 +34,9 @@ namespace
 {
   /* A C++ ]AT_NAME_PREFIX[parse that simulates the C signature.  */
   int
-  ]AT_NAME_PREFIX[parse (]AT_PARAM_IF([semantic_value *result, int *count]))[
+  ]AT_NAME_PREFIX[parse (]AT_PARAM_IF([semantic_value *result, int *count, int *nerrs]))[
   {
-    ]AT_NAME_PREFIX[::parser parser]AT_PARAM_IF([ (result, count)])[;
+    ]AT_NAME_PREFIX[::parser parser]AT_PARAM_IF([ (result, count, nerrs)])[;
   #if ]AT_API_PREFIX[DEBUG
     parser.set_debug_level (1);
   #endif
@@ -49,13 +49,16 @@ namespace
 semantic_value global_result = 0;
 /* Total number of computations.  */
 int global_count = 0;
+/* Total number of errors.  */
+int global_nerrs = 0;
 
 /* A C main function.  */
 int
 main (int argc, const char **argv)
 {]AT_PARAM_IF([[
   semantic_value result = 0;
-  int count = 0;]])[
+  int count = 0;
+  int nerrs = 0;]])[
   int status;
 
   /* This used to be alarm (10), but that isn't enough time for a July
@@ -77,12 +80,13 @@ main (int argc, const char **argv)
     }
 
 ]AT_CXX_IF([], [AT_DEBUG_IF([  ]AT_NAME_PREFIX[debug = 1;])])[
-  status = ]AT_NAME_PREFIX[parse (]AT_PARAM_IF([[&result, &count]])[);
+  status = ]AT_NAME_PREFIX[parse (]AT_PARAM_IF([[&result, &count, &nerrs]])[);
   if (fclose (input))
     perror ("fclose");]AT_PARAM_IF([[
   assert (global_result == result); (void) result;
   assert (global_count  == count);  (void) count;
-  printf ("final: %d %d\n", global_result, global_count);]])[
+  assert (global_nerrs  == nerrs);  (void) nerrs;
+  printf ("final: %d %d %d\n", global_result, global_count, global_nerrs);]])[
   return status;
 }
 ]])
@@ -399,6 +403,7 @@ void location_print (FILE *o, Span s);
   extern FILE *input;
   extern semantic_value global_result;
   extern int global_count;
+  extern int global_nerrs;
 }
 
 %code
@@ -682,35 +687,35 @@ _AT_CHECK_CALC([$1],
 
 2^2^3 = 256
 (2^2)^3 = 64],
-[[final: 64 12]],
+[[final: 64 12 0]],
                [AT_PUSH_IF([930], [846])])
 
 # Some syntax errors.
 _AT_CHECK_CALC_ERROR([$1], [1], [1 2],
-                     [[final: 0 0]],
+                     [[final: 0 0 1]],
                      [15],
                      [[1.3: syntax error on token ["number"] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] ['\n'])]])
 _AT_CHECK_CALC_ERROR([$1], [1], [1//2],
-                     [[final: 0 0]],
+                     [[final: 0 0 1]],
                      [20],
                      [[1.3: syntax error on token ['/'] (expected: ["number"] ['-'] ['('] ['!'])]])
 _AT_CHECK_CALC_ERROR([$1], [1], [error],
-                     [[final: 0 0]],
+                     [[final: 0 0 1]],
                      [5],
                      [[1.1: syntax error on token [$undefined] (expected: ["number"] ['-'] ['\n'] ['('] ['!'])]])
 _AT_CHECK_CALC_ERROR([$1], [1], [1 = 2 = 3],
-                     [[final: 0 0]],
+                     [[final: 0 0 1]],
                      [30],
                      [[1.7: syntax error on token ['='] (expected: ['-'] ['+'] ['*'] ['/'] ['^'])]])
 _AT_CHECK_CALC_ERROR([$1], [1],
                      [
 +1],
-                     [[final: 0 0]],
+                     [[final: 0 0 1]],
                      [20],
                      [[2.1: syntax error on token ['+'] (expected: ["end of input"] ["number"] ['-'] ['\n'] ['('] ['!'])]])
 # Exercise error messages with EOF: work on an empty file.
 _AT_CHECK_CALC_ERROR([$1], [1], [/dev/null],
-                     [[final: 0 0]],
+                     [[final: 0 0 1]],
                      [4],
                      [[1.1: syntax error on token ["end of input"] (expected: ["number"] ['-'] ['\n'] ['('] ['!'])]])
 
@@ -732,7 +737,7 @@ _AT_CHECK_CALC_ERROR([$1], [1], [/dev/null],
 #
 _AT_CHECK_CALC_ERROR([$1], [0],
                      [() + (1 + 1 + 1 +) + (* * *) + (1 * 2 * *) = 1],
-                     [[final: 4444 0]],
+                     [[final: 4444 0 4]],
                      [250],
 [[1.2: syntax error on token [')'] (expected: ["number"] ['-'] ['('] ['!'])
 1.18: syntax error on token [')'] (expected: ["number"] ['-'] ['('] ['!'])
@@ -743,12 +748,12 @@ calc: error: 4444 != 1]])
 # The same, but this time exercising explicitly triggered syntax errors.
 # POSIX says the lookahead causing the error should not be discarded.
 _AT_CHECK_CALC_ERROR([$1], [0], [(!) + (1 2) = 1],
-                     [[final: 2222 0]],
+                     [[final: 2222 0 1]],
                      [102],
 [[1.10: syntax error on token ["number"] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] [')'])
 calc: error: 2222 != 1]])
 _AT_CHECK_CALC_ERROR([$1], [0], [(- *) + (1 2) = 1],
-                     [[final: 2222 0]],
+                     [[final: 2222 0 2]],
                      [113],
 [[1.4: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
 1.12: syntax error on token ["number"] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] [')'])
@@ -757,7 +762,7 @@ calc: error: 2222 != 1]])
 # Check that yyerrok works properly: second error is not reported,
 # third and fourth are.  Parse status is succesful.
 _AT_CHECK_CALC_ERROR([$1], [0], [(* *) + (*) + (*)],
-                     [[final: 3333 0]],
+                     [[final: 3333 0 3]],
                      [113],
 [[1.2: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
 1.10: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
@@ -809,14 +814,14 @@ AT_CHECK_CALC_LALR([%define parse.error verbose %debug %locations %defines %defi
 AT_CHECK_CALC_LALR([%define api.pure full %define parse.error verbose %debug %locations %defines %name-prefix "calc" %verbose %yacc])
 AT_CHECK_CALC_LALR([%define api.push-pull both %define api.pure full %define parse.error verbose %debug %locations %defines %define api.prefix {calc} %verbose %yacc])
 
-AT_CHECK_CALC_LALR([%define api.pure %define parse.error verbose %debug %locations %defines %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}])
+AT_CHECK_CALC_LALR([%define api.pure %define parse.error verbose %debug %locations %defines %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 
-AT_CHECK_CALC_LALR([%no-lines %define api.pure %define parse.error verbose %debug %locations %defines %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}])
+AT_CHECK_CALC_LALR([%no-lines %define api.pure %define parse.error verbose %debug %locations %defines %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 
 
 AT_CHECK_CALC_LALR([%define parse.error custom])
 AT_CHECK_CALC_LALR([%define parse.error custom %locations %define api.prefix {calc}])
-AT_CHECK_CALC_LALR([%define parse.error custom %locations %define api.prefix {calc} %parse-param {semantic_value *result}{int *count}])
+AT_CHECK_CALC_LALR([%define parse.error custom %locations %define api.prefix {calc} %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 
 # ----------------------- #
 # Simple GLR Calculator.  #
@@ -854,10 +859,10 @@ AT_CHECK_CALC_GLR([%define parse.error verbose %debug %locations %defines %defin
 
 AT_CHECK_CALC_GLR([%define api.pure %define parse.error verbose %debug %locations %defines %name-prefix "calc" %verbose %yacc])
 
-AT_CHECK_CALC_GLR([%define api.pure %define parse.error verbose %debug %locations %defines %name-prefix "calc" %verbose %yacc %parse-param {semantic_value *result}{int *count}])
-AT_CHECK_CALC_GLR([%define api.pure %define parse.error verbose %debug %locations %defines %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}])
+AT_CHECK_CALC_GLR([%define api.pure %define parse.error verbose %debug %locations %defines %name-prefix "calc" %verbose %yacc %parse-param {semantic_value *result}{int *count}{int *nerrs}])
+AT_CHECK_CALC_GLR([%define api.pure %define parse.error verbose %debug %locations %defines %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 
-AT_CHECK_CALC_GLR([%no-lines %define api.pure %define parse.error verbose %debug %locations %defines %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}])
+AT_CHECK_CALC_GLR([%no-lines %define api.pure %define parse.error verbose %debug %locations %defines %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 
 
 # ----------------------------- #
@@ -888,10 +893,10 @@ AT_CHECK_CALC_LALR1_CC([%locations %define parse.error verbose %debug %name-pref
 AT_CHECK_CALC_LALR1_CC([%locations %define parse.error verbose %debug %define api.prefix {calc} %verbose %yacc])
 AT_CHECK_CALC_LALR1_CC([%locations %define parse.error verbose %debug %define api.prefix {calc} %define api.token.prefix {TOK_} %verbose %yacc])
 
-AT_CHECK_CALC_LALR1_CC([%defines %locations %define parse.error verbose %debug %name-prefix "calc" %verbose %yacc %parse-param {semantic_value *result}{int *count}])
+AT_CHECK_CALC_LALR1_CC([%defines %locations %define parse.error verbose %debug %name-prefix "calc" %verbose %yacc %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 
-AT_CHECK_CALC_LALR1_CC([%define parse.error verbose %debug %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}])
-AT_CHECK_CALC_LALR1_CC([%defines %locations %define parse.error verbose %debug %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}])
+AT_CHECK_CALC_LALR1_CC([%define parse.error verbose %debug %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}{int *nerrs}])
+AT_CHECK_CALC_LALR1_CC([%defines %locations %define parse.error verbose %debug %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 
 AT_CHECK_CALC_LALR1_CC([%defines %locations %define api.location.file none])
 AT_CHECK_CALC_LALR1_CC([%defines %locations %define api.location.file "my-location.hh"])
@@ -926,10 +931,10 @@ AT_CHECK_CALC_GLR_CC([%debug])
 AT_CHECK_CALC_GLR_CC([%define parse.error verbose %debug %name-prefix "calc" %verbose %yacc])
 AT_CHECK_CALC_GLR_CC([%define parse.error verbose %debug %name-prefix "calc" %define api.token.prefix {TOK_} %verbose %yacc])
 
-AT_CHECK_CALC_GLR_CC([%locations %defines %define parse.error verbose %debug %name-prefix "calc" %verbose %yacc %parse-param {semantic_value *result}{int *count}])
-AT_CHECK_CALC_GLR_CC([%locations %defines %define parse.error verbose %debug %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}])
+AT_CHECK_CALC_GLR_CC([%locations %defines %define parse.error verbose %debug %name-prefix "calc" %verbose %yacc %parse-param {semantic_value *result}{int *count}{int *nerrs}])
+AT_CHECK_CALC_GLR_CC([%locations %defines %define parse.error verbose %debug %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 
-AT_CHECK_CALC_GLR_CC([%no-lines %locations %defines %define parse.error verbose %debug %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}])
+AT_CHECK_CALC_GLR_CC([%no-lines %locations %defines %define parse.error verbose %debug %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 
 
 # --------------------------- #
@@ -958,8 +963,8 @@ AT_CHECK_CALC_LALR1_D([%debug])
 AT_CHECK_CALC_LALR1_D([%define parse.error verbose %debug %verbose])
 #AT_CHECK_CALC_LALR1_D([%define parse.error verbose %debug %define api.token.prefix {TOK_} %verbose])
 
-#AT_CHECK_CALC_LALR1_D([%locations %define parse.error verbose %debug %verbose %parse-param {semantic_value *result}{int *count}])
-#AT_CHECK_CALC_LALR1_D([%locations %define parse.error verbose %debug %define api.prefix {calc} %verbose %parse-param {semantic_value *result}{int *count}])
+#AT_CHECK_CALC_LALR1_D([%locations %define parse.error verbose %debug %verbose %parse-param {semantic_value *result}{int *count}{int *nerrs}])
+#AT_CHECK_CALC_LALR1_D([%locations %define parse.error verbose %debug %define api.prefix {calc} %verbose %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 
 m4_popdef([AT_CALC_MAIN])
 m4_popdef([AT_CALC_YYLEX])

--- a/tests/calc.at
+++ b/tests/calc.at
@@ -45,15 +45,17 @@ namespace
 }
 ]])[
 
+/* Value of the last computation.  */
 semantic_value global_result = 0;
+/* Total number of computations.  */
 int global_count = 0;
 
 /* A C main function.  */
 int
 main (int argc, const char **argv)
-{
+{]AT_PARAM_IF([[
   semantic_value result = 0;
-  int count = 0;
+  int count = 0;]])[
   int status;
 
   /* This used to be alarm (10), but that isn't enough time for a July
@@ -77,9 +79,10 @@ main (int argc, const char **argv)
 ]AT_CXX_IF([], [AT_DEBUG_IF([  ]AT_NAME_PREFIX[debug = 1;])])[
   status = ]AT_NAME_PREFIX[parse (]AT_PARAM_IF([[&result, &count]])[);
   if (fclose (input))
-    perror ("fclose");
+    perror ("fclose");]AT_PARAM_IF([[
   assert (global_result == result); (void) result;
-  assert (global_count == count);   (void) count;
+  assert (global_count  == count);  (void) count;
+  printf ("final: %d %d\n", global_result, global_count);]])[
   return status;
 }
 ]])
@@ -88,13 +91,14 @@ m4_copy([AT_CALC_MAIN(c)], [AT_CALC_MAIN(c++)])
 
 m4_define([AT_CALC_MAIN(d)],
 [[int main (string[] args)
-{
+{]AT_PARAM_IF([[
   semantic_value result = 0;
-  int count = 0;
+  int count = 0;]])[
 
   File input = args.length == 2 ? File (args[1], "r") : stdin;
   auto l = calcLexer (input);
-  auto p = new YYParser (l);
+  auto p = new YYParser (l);]AT_DEBUG_IF([[
+  p.setDebugLevel (1);]])[
   return !p.parse ();
 }
 ]])
@@ -527,8 +531,8 @@ m4_define([AT_DATA_CALC_Y],
 
 
 
-# _AT_CHECK_CALC(BISON-OPTIONS, INPUT, [NUM-STDERR-LINES])
-# --------------------------------------------------------
+# _AT_CHECK_CALC(BISON-OPTIONS, INPUT, [STDOUT], [NUM-STDERR-LINES])
+# ------------------------------------------------------------------
 # Run 'calc' on INPUT and expect no STDOUT nor STDERR.
 #
 # If BISON-OPTIONS contains '%debug' but not '%glr-parser', then
@@ -536,18 +540,22 @@ m4_define([AT_DATA_CALC_Y],
 # Currently this is ignored, though, since the output format is fluctuating.
 #
 # We don't count GLR's traces yet, since its traces are somewhat
-# different from LALR's.
+# different from LALR's.  Likewise for D.
 m4_define([_AT_CHECK_CALC],
 [AT_DATA([[input]],
 [[$2
 ]])
-AT_PARSER_CHECK([calc input], 0, [], [stderr])
+AT_PARSER_CHECK([calc input], 0, [AT_PARAM_IF([m4_n([$3])])], [stderr])
+AT_D_IF([],
+  [AT_GLR_IF([],
+    [AT_CHECK([cat stderr | wc -l], [0], [m4_n([AT_DEBUG_IF([$4], [0])])])])])
 ])
 
 
 # _AT_CHECK_CALC_ERROR($1 = BISON-OPTIONS, $2 = EXIT-STATUS, $3 = INPUT,
-#                      $4 = [NUM-STDERR-LINES],
-#                      $5 = [CUSTOM-ERROR-MESSAGE])
+#                      $4 = [STDOUT],
+#                      $5 = [NUM-STDERR-LINES],
+#                      $6 = [CUSTOM-ERROR-MESSAGE])
 # ----------------------------------------------------------------------
 # Run 'calc' on INPUT, and expect a 'syntax error' message.
 #
@@ -563,11 +571,11 @@ AT_PARSER_CHECK([calc input], 0, [], [stderr])
 # computed from it.
 m4_define([_AT_CHECK_CALC_ERROR],
 [m4_bmatch([$3], [^/],
-           [AT_PARSER_CHECK([calc $3], $2, [], [stderr])],
+           [AT_PARSER_CHECK([calc $3], $2, [AT_PARAM_IF([m4_n([$4])])], [stderr])],
            [AT_DATA([[input]],
 [[$3
 ]])
-AT_PARSER_CHECK([calc input], $2, [], [stderr])])
+AT_PARSER_CHECK([calc input], $2, [AT_PARAM_IF([m4_n([$4])])], [stderr])])
 
 # Normalize the observed and expected error messages, depending upon the
 # options.
@@ -591,7 +599,7 @@ mv at-stderr stderr
 
 # 2. Create the reference error message.
 AT_DATA([[expout]],
-[$5
+[$6
 ])
 
 # 3. If locations are not used, remove them.
@@ -674,24 +682,36 @@ _AT_CHECK_CALC([$1],
 
 2^2^3 = 256
 (2^2)^3 = 64],
-               [842])
+[[final: 64 12]],
+               [AT_PUSH_IF([930], [846])])
 
 # Some syntax errors.
-_AT_CHECK_CALC_ERROR([$1], [1], [1 2], [15],
+_AT_CHECK_CALC_ERROR([$1], [1], [1 2],
+                     [[final: 0 0]],
+                     [15],
                      [[1.3: syntax error on token ["number"] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] ['\n'])]])
-_AT_CHECK_CALC_ERROR([$1], [1], [1//2], [20],
+_AT_CHECK_CALC_ERROR([$1], [1], [1//2],
+                     [[final: 0 0]],
+                     [20],
                      [[1.3: syntax error on token ['/'] (expected: ["number"] ['-'] ['('] ['!'])]])
-_AT_CHECK_CALC_ERROR([$1], [1], [error], [5],
+_AT_CHECK_CALC_ERROR([$1], [1], [error],
+                     [[final: 0 0]],
+                     [5],
                      [[1.1: syntax error on token [$undefined] (expected: ["number"] ['-'] ['\n'] ['('] ['!'])]])
-_AT_CHECK_CALC_ERROR([$1], [1], [1 = 2 = 3], [30],
+_AT_CHECK_CALC_ERROR([$1], [1], [1 = 2 = 3],
+                     [[final: 0 0]],
+                     [30],
                      [[1.7: syntax error on token ['='] (expected: ['-'] ['+'] ['*'] ['/'] ['^'])]])
 _AT_CHECK_CALC_ERROR([$1], [1],
                      [
 +1],
+                     [[final: 0 0]],
                      [20],
                      [[2.1: syntax error on token ['+'] (expected: ["end of input"] ["number"] ['-'] ['\n'] ['('] ['!'])]])
 # Exercise error messages with EOF: work on an empty file.
-_AT_CHECK_CALC_ERROR([$1], [1], [/dev/null], [4],
+_AT_CHECK_CALC_ERROR([$1], [1], [/dev/null],
+                     [[final: 0 0]],
+                     [4],
                      [[1.1: syntax error on token ["end of input"] (expected: ["number"] ['-'] ['\n'] ['('] ['!'])]])
 
 # Exercise the error token: without it, we die at the first error,
@@ -712,6 +732,7 @@ _AT_CHECK_CALC_ERROR([$1], [1], [/dev/null], [4],
 #
 _AT_CHECK_CALC_ERROR([$1], [0],
                      [() + (1 + 1 + 1 +) + (* * *) + (1 * 2 * *) = 1],
+                     [[final: 4444 0]],
                      [250],
 [[1.2: syntax error on token [')'] (expected: ["number"] ['-'] ['('] ['!'])
 1.18: syntax error on token [')'] (expected: ["number"] ['-'] ['('] ['!'])
@@ -721,17 +742,23 @@ calc: error: 4444 != 1]])
 
 # The same, but this time exercising explicitly triggered syntax errors.
 # POSIX says the lookahead causing the error should not be discarded.
-_AT_CHECK_CALC_ERROR([$1], [0], [(!) + (1 2) = 1], [102],
+_AT_CHECK_CALC_ERROR([$1], [0], [(!) + (1 2) = 1],
+                     [[final: 2222 0]],
+                     [102],
 [[1.10: syntax error on token ["number"] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] [')'])
 calc: error: 2222 != 1]])
-_AT_CHECK_CALC_ERROR([$1], [0], [(- *) + (1 2) = 1], [113],
+_AT_CHECK_CALC_ERROR([$1], [0], [(- *) + (1 2) = 1],
+                     [[final: 2222 0]],
+                     [113],
 [[1.4: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
 1.12: syntax error on token ["number"] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] [')'])
 calc: error: 2222 != 1]])
 
 # Check that yyerrok works properly: second error is not reported,
 # third and fourth are.  Parse status is succesful.
-_AT_CHECK_CALC_ERROR([$1], [0], [(* *) + (*) + (*)], [113],
+_AT_CHECK_CALC_ERROR([$1], [0], [(* *) + (*) + (*)],
+                     [[final: 3333 0]],
+                     [113],
 [[1.2: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
 1.10: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
 1.16: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])]])

--- a/tests/calc.at
+++ b/tests/calc.at
@@ -788,7 +788,8 @@ AT_CHECK_CALC_LALR([%no-lines %define api.pure %define parse.error verbose %debu
 
 
 AT_CHECK_CALC_LALR([%define parse.error custom])
-AT_CHECK_CALC_LALR([%define parse.error custom %locations])
+AT_CHECK_CALC_LALR([%define parse.error custom %locations %define api.prefix {calc}])
+AT_CHECK_CALC_LALR([%define parse.error custom %locations %define api.prefix {calc} %parse-param {semantic_value *result}{int *count}])
 
 # ----------------------- #
 # Simple GLR Calculator.  #

--- a/tests/calc.at
+++ b/tests/calc.at
@@ -545,10 +545,11 @@ AT_PARSER_CHECK([calc input], 0, [], [stderr])
 ])
 
 
-# _AT_CHECK_CALC_ERROR(BISON-OPTIONS, EXIT-STATUS, INPUT,
-#                      [NUM-STDERR-LINES],
-#                      [VERBOSE-AND-LOCATED-ERROR-MESSAGE])
-# ---------------------------------------------------------
+# _AT_CHECK_CALC_ERROR($1 = BISON-OPTIONS, $2 = EXIT-STATUS, $3 = INPUT,
+#                      $4 = [NUM-STDERR-LINES],
+#                      $5 = [VERBOSE-AND-LOCATED-ERROR-MESSAGE]
+#                      $6 = [CUSTOM-ERROR-MESSAGE])
+# ----------------------------------------------------------------------
 # Run 'calc' on INPUT, and expect a 'syntax error' message.
 #
 # If INPUT starts with a slash, it is used as absolute input file name,
@@ -595,8 +596,14 @@ sed '/^Starting/d
 mv at-stderr stderr
 
 # 2. Create the reference error message.
-AT_DATA([[expout]],
+AT_ERROR_CUSTOM_IF([
+  AT_DATA([[expout]],
+[$6
+])
+],
+  [AT_DATA([[expout]],
 [$5
+])
 ])
 
 # 3. If locations are not used, remove them.
@@ -605,7 +612,7 @@ AT_YYERROR_SEES_LOC_IF([],
 mv at-expout expout]])
 
 # 4. If error-verbose is not used, strip the', unexpected....' part.
-m4_bmatch([$1], [%define parse.error verbose], [],
+AT_ERROR_SIMPLE_IF(
 [[sed 's/syntax error, .*$/syntax error/' expout >at-expout
 mv at-expout expout]])
 
@@ -668,21 +675,27 @@ _AT_CHECK_CALC([$1],
 
 # Some syntax errors.
 _AT_CHECK_CALC_ERROR([$1], [1], [1 2], [15],
-                     [1.3: syntax error, unexpected number])
+                     [[1.3: syntax error, unexpected number]],
+                     [[1.3: syntax error on token ["number"] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] ['\n'])]])
 _AT_CHECK_CALC_ERROR([$1], [1], [1//2], [20],
-                     [1.3: syntax error, unexpected '/', expecting number or '-' or '(' or '!'])
+                     [[1.3: syntax error, unexpected '/', expecting number or '-' or '(' or '!']],
+                     [[1.3: syntax error on token ['/'] (expected: ["number"] ['-'] ['('] ['!'])]])
 _AT_CHECK_CALC_ERROR([$1], [1], [error], [5],
-                     [1.1: syntax error, unexpected $undefined])
+                     [[1.1: syntax error, unexpected $undefined]],
+                     [[1.1: syntax error on token [$undefined] (expected: ["number"] ['-'] ['\n'] ['('] ['!'])]])
 _AT_CHECK_CALC_ERROR([$1], [1], [1 = 2 = 3], [30],
-                     [1.7: syntax error, unexpected '='])
+                     [[1.7: syntax error, unexpected '=']],
+                     [[1.7: syntax error on token ['='] (expected: ['-'] ['+'] ['*'] ['/'] ['^'])]])
 _AT_CHECK_CALC_ERROR([$1], [1],
                      [
 +1],
                      [20],
-                     [2.1: syntax error, unexpected '+'])
+                     [[2.1: syntax error, unexpected '+']],
+                     [[2.1: syntax error on token ['+'] (expected: ["end of input"] ["number"] ['-'] ['\n'] ['('] ['!'])]])
 # Exercise error messages with EOF: work on an empty file.
 _AT_CHECK_CALC_ERROR([$1], [1], [/dev/null], [4],
-                     [1.1: syntax error, unexpected end of input])
+                     [[1.1: syntax error, unexpected end of input]],
+                     [[1.1: syntax error on token ["end of input"] (expected: ["number"] ['-'] ['\n'] ['('] ['!'])]])
 
 # Exercise the error token: without it, we die at the first error,
 # hence be sure to
@@ -703,28 +716,41 @@ _AT_CHECK_CALC_ERROR([$1], [1], [/dev/null], [4],
 _AT_CHECK_CALC_ERROR([$1], [0],
                      [() + (1 + 1 + 1 +) + (* * *) + (1 * 2 * *) = 1],
                      [250],
-[1.2: syntax error, unexpected ')', expecting number or '-' or '(' or '!'
+[[1.2: syntax error, unexpected ')', expecting number or '-' or '(' or '!'
 1.18: syntax error, unexpected ')', expecting number or '-' or '(' or '!'
 1.23: syntax error, unexpected '*', expecting number or '-' or '(' or '!'
 1.41: syntax error, unexpected '*', expecting number or '-' or '(' or '!'
-calc: error: 4444 != 1])
+calc: error: 4444 != 1]],
+[[1.2: syntax error on token [')'] (expected: ["number"] ['-'] ['('] ['!'])
+1.18: syntax error on token [')'] (expected: ["number"] ['-'] ['('] ['!'])
+1.23: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
+1.41: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
+calc: error: 4444 != 1]])
 
 # The same, but this time exercising explicitly triggered syntax errors.
 # POSIX says the lookahead causing the error should not be discarded.
 _AT_CHECK_CALC_ERROR([$1], [0], [(!) + (1 2) = 1], [102],
-[1.10: syntax error, unexpected number
-calc: error: 2222 != 1])
+[[1.10: syntax error, unexpected number
+calc: error: 2222 != 1]],
+[[1.10: syntax error on token ["number"] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] [')'])
+calc: error: 2222 != 1]])
 _AT_CHECK_CALC_ERROR([$1], [0], [(- *) + (1 2) = 1], [113],
-[1.4: syntax error, unexpected '*', expecting number or '-' or '(' or '!'
+[[1.4: syntax error, unexpected '*', expecting number or '-' or '(' or '!'
 1.12: syntax error, unexpected number
-calc: error: 2222 != 1])
+calc: error: 2222 != 1]],
+[[1.4: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
+1.12: syntax error on token ["number"] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] [')'])
+calc: error: 2222 != 1]])
 
 # Check that yyerrok works properly: second error is not reported,
 # third and fourth are.  Parse status is succesful.
 _AT_CHECK_CALC_ERROR([$1], [0], [(* *) + (*) + (*)], [113],
-[1.2: syntax error, unexpected '*', expecting number or '-' or '(' or '!'
+[[1.2: syntax error, unexpected '*', expecting number or '-' or '(' or '!'
 1.10: syntax error, unexpected '*', expecting number or '-' or '(' or '!'
-1.16: syntax error, unexpected '*', expecting number or '-' or '(' or '!'])
+1.16: syntax error, unexpected '*', expecting number or '-' or '(' or '!']],
+[[1.2: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
+1.10: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
+1.16: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])]])
 
 AT_BISON_OPTION_POPDEFS
 
@@ -776,6 +802,8 @@ AT_CHECK_CALC_LALR([%define api.pure %define parse.error verbose %debug %locatio
 
 AT_CHECK_CALC_LALR([%no-lines %define api.pure %define parse.error verbose %debug %locations %defines %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}])
 
+
+AT_CHECK_CALC_LALR([%define parse.error custom])
 
 # ----------------------- #
 # Simple GLR Calculator.  #

--- a/tests/calc.at
+++ b/tests/calc.at
@@ -788,6 +788,7 @@ AT_CHECK_CALC_LALR([%no-lines %define api.pure %define parse.error verbose %debu
 
 
 AT_CHECK_CALC_LALR([%define parse.error custom])
+AT_CHECK_CALC_LALR([%define parse.error custom %locations])
 
 # ----------------------- #
 # Simple GLR Calculator.  #

--- a/tests/local.at
+++ b/tests/local.at
@@ -203,7 +203,13 @@ m4_pushdef([AT_AUTOMOVE_IF],
 m4_pushdef([AT_DEFINES_IF],
 [m4_bmatch([$3], [%defines], [$1], [$2])])
 m4_pushdef([AT_DEBUG_IF],
-[m4_bmatch([$3], [%debug\|%define parse.trace], [$1], [$2])])
+           [m4_bmatch([$3], [%debug\|%define parse.trace], [$1], [$2])])
+m4_pushdef([AT_ERROR_CUSTOM_IF],
+           [m4_bmatch([$3], [%define parse\.error custom], [$1], [$2])])
+m4_pushdef([AT_ERROR_VERBOSE_IF],
+           [m4_bmatch([$3], [%define parse\.error verbose], [$1], [$2])])
+m4_pushdef([AT_ERROR_SIMPLE_IF],
+           [AT_ERROR_CUSTOM_IF([$2], [AT_ERROR_VERBOSE_IF([$2], [$1])], [$1])])
 m4_pushdef([AT_CXX_IF],
 [m4_bmatch([$3], [%language "[Cc]\+\+"\|%skeleton "[a-z0-9]+\.cc"], [$1], [$2])])
 m4_pushdef([AT_D_IF],
@@ -409,8 +415,12 @@ m4_popdef([AT_LANG])
 m4_popdef([AT_JAVA_IF])
 m4_popdef([AT_GLR_CC_IF])
 m4_popdef([AT_LALR1_CC_IF])
-m4_popdef([AT_DEFINES_IF])
+m4_popdef([AT_ERROR_SIMPLE_IF])
+m4_popdef([AT_ERROR_VERBOSE_IF])
+m4_popdef([AT_ERROR_CUSTOM_IF])
 m4_popdef([AT_DEBUG_IF])
+m4_popdef([AT_DEFINES_IF])
+m4_popdef([AT_AUTOMOVE_IF])
 AT_LOC_POPDEF])dnl
 ])# AT_BISON_OPTION_POPDEFS
 
@@ -552,7 +562,7 @@ m4_define([AT_YYERROR_DECLARE_EXTERN(c)],
 [AT_YYERROR_PROTOTYPE;])
 
 m4_define([AT_YYERROR_DECLARE(c)],
-[#include <stdio.h>
+[[#include <stdio.h>
 ]AT_LOCATION_IF([[
 #if defined ]AT_YYLTYPE[_IS_TRIVIAL && ]AT_YYLTYPE[_IS_TRIVIAL
 static int location_print (FILE *yyo, ]AT_YYLTYPE[ const * const yylocp);
@@ -561,12 +571,11 @@ static int location_print (FILE *yyo, ]AT_YYLTYPE[ const * const yylocp);
 # endif
 #endif
 ]])[
-static AT_YYERROR_DECLARE_EXTERN])
+static ]AT_YYERROR_DECLARE_EXTERN])
 
 
 m4_define([AT_YYERROR_DEFINE(c)],
-[[
-]AT_LOCATION_IF([[
+[AT_LOCATION_IF([[
 # if defined ]AT_YYLTYPE[_IS_TRIVIAL && ]AT_YYLTYPE[_IS_TRIVIAL
 /* Print *YYLOCP on YYO. */
 __attribute__((__unused__))
@@ -596,6 +605,33 @@ location_print (FILE *yyo, ]AT_YYLTYPE[ const * const yylocp)
 }
 #endif
 ]])[
+
+]AT_ERROR_CUSTOM_IF([[
+int
+yyreport_syntax_error (const yyparse_context_t *ctx)
+{
+  /* Arguments of yyformat: reported tokens (one for the "unexpected",
+     one per "expected"). */
+  int arg[YYNTOKENS];
+  int n = yysyntax_error_arguments (ctx, arg, sizeof arg / sizeof *arg);
+  if (n == -2)
+    return 2;
+  if (n)
+  {
+    fprintf (stderr, "syntax error on token [%s]", yysymbol_name (arg[0]));
+    if (1 < n)
+      {
+        fprintf (stderr, " (expected:");
+        for (int i = 1; i < n; ++i)
+          fprintf (stderr, " [%s]", yysymbol_name (arg[i]));
+        fprintf (stderr, ")");
+      }
+    fprintf (stderr, "\n");
+  }
+  return 0;
+}
+]])[
+
 /* A C error reporting function.  */
 static
 ]AT_YYERROR_PROTOTYPE[
@@ -606,7 +642,7 @@ AT_YYERROR_SEES_LOC_IF([[
   LOCATION_PRINT (stderr, ]AT_LOC[);
   fprintf (stderr, ": ");]])[
   fprintf (stderr, "%s\n", msg);
-}]])
+}]])])
 
 
 m4_define([AT_YYLEX_DEFINE(c)],

--- a/tests/local.at
+++ b/tests/local.at
@@ -615,7 +615,7 @@ yyreport_syntax_error (const yyparse_context_t *ctx]AT_PARAM_IF([, AT_PARSE_PARA
   /* Arguments of yyformat: reported tokens (one for the "unexpected",
      one per "expected"). */
   int arg[YYNTOKENS];
-  int n = yysyntax_error_arguments (ctx, arg, sizeof arg / sizeof *arg);]AT_PARAM_IF([m4_bpatsubst(m4_defn([AT_PARSE_PARAMS]),
+  int n = yysyntax_error_arguments (ctx, arg, YYNTOKENS);]AT_PARAM_IF([m4_bpatsubst(m4_defn([AT_PARSE_PARAMS]),
               [[^,]+[^A-Za-z_0-9]\([A-Za-z_][A-Za-z_0-9]*\),* *], [
   YYUSE (\1);])])[]m4_bmatch(m4_defn([AT_PARSE_PARAMS]), [nerrs],[[
   ++global_nerrs;

--- a/tests/local.at
+++ b/tests/local.at
@@ -619,7 +619,9 @@ yyreport_syntax_error (const yyparse_context_t *ctx)
   if (n == -2)
     return 2;
   if (n)
-  {
+  {]AT_LOCATION_IF([[
+    LOCATION_PRINT (stderr, *yyparse_context_location (ctx));
+    fprintf (stderr, ": ");]])[
     fprintf (stderr, "syntax error on token [%s]", yysymbol_name (arg[0]));
     if (1 < n)
       {

--- a/tests/local.at
+++ b/tests/local.at
@@ -610,12 +610,16 @@ location_print (FILE *yyo, ]AT_YYLTYPE[ const * const yylocp)
 
 ]AT_ERROR_CUSTOM_IF([[
 int
-yyreport_syntax_error (const yyparse_context_t *ctx)
+yyreport_syntax_error (const yyparse_context_t *ctx]AT_PARAM_IF([, AT_PARSE_PARAMS])[)
 {
   /* Arguments of yyformat: reported tokens (one for the "unexpected",
      one per "expected"). */
   int arg[YYNTOKENS];
-  int n = yysyntax_error_arguments (ctx, arg, sizeof arg / sizeof *arg);
+  int n = yysyntax_error_arguments (ctx, arg, sizeof arg / sizeof *arg);]AT_PARAM_IF([m4_bpatsubst(m4_defn([AT_PARSE_PARAMS]),
+              [[^,]+[^A-Za-z_0-9]\([A-Za-z_][A-Za-z_0-9]*\),* *], [
+  YYUSE (\1);])])[]m4_bmatch(m4_defn([AT_PARSE_PARAMS]), [nerrs],[[
+  ++global_nerrs;
+  ++*nerrs;]])[
   if (n == -2)
     return 2;
   if (n)
@@ -645,7 +649,9 @@ static
 AT_YYERROR_SEES_LOC_IF([[
   LOCATION_PRINT (stderr, ]AT_LOC[);
   fprintf (stderr, ": ");]])[
-  fprintf (stderr, "%s\n", msg);
+  fprintf (stderr, "%s\n", msg);]m4_bmatch(m4_defn([AT_PARSE_PARAMS]), [nerrs],[[
+  ++global_nerrs;
+  ++*nerrs;]])[
 }]])])
 
 
@@ -711,7 +717,9 @@ m4_define([AT_YYERROR_DEFINE(c++)],
 [[/* A C++ error reporting function.  */
 void
 ]AT_NAMESPACE[::parser::error (]AT_LOCATION_IF([[const location_type& l, ]])[const std::string& m)
-{
+{]m4_bmatch(m4_defn([AT_PARSE_PARAMS]), [nerrs],[[
+  ++global_nerrs;
+  ++*nerrs;]])[
   std::cerr << ]AT_LOCATION_IF([l << ": " << ])[m << '\n';
 }]])
 
@@ -848,15 +856,19 @@ m4_define([AT_JAVA_POSITION_DEFINE],
 
 m4_define([AT_YYERROR_DEFINE(java)],
 [AT_LOCATION_IF([[public void yyerror (Calc.Location l, String m)
-{
-  if (l == null)
-    System.err.println (m);
-  else
-    System.err.println (l + ": " + m);
+  {]m4_bmatch(m4_defn([AT_PARSE_PARAMS]), [nerrs],[[
+    ++global_nerrs;
+    ++*nerrs;]])[
+    if (l == null)
+      System.err.println (m);
+    else
+      System.err.println (l + ": " + m);
   }
 ]], [[
   public void yyerror (String m)
-  {
+  {]m4_bmatch(m4_defn([AT_PARSE_PARAMS]), [nerrs],[[
+    ++global_nerrs;
+    ++*nerrs;]])[
     System.err.println (m);
   }
 ]])

--- a/tests/local.at
+++ b/tests/local.at
@@ -574,6 +574,8 @@ static int location_print (FILE *yyo, ]AT_YYLTYPE[ const * const yylocp);
 static ]AT_YYERROR_DECLARE_EXTERN])
 
 
+# "%define parse.error custom" uses a different format, easy to check.
+# The "verbose" one can be computed from it (see _AT_CHECK_CALC_ERROR).
 m4_define([AT_YYERROR_DEFINE(c)],
 [AT_LOCATION_IF([[
 # if defined ]AT_YYLTYPE[_IS_TRIVIAL && ]AT_YYLTYPE[_IS_TRIVIAL

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -26,7 +26,7 @@ m4_include([named-refs.at])
 # Output file names.
 m4_include([output.at])
 
-# Diagnostics.
+# Bison diagnostics.
 m4_include([diagnostics.at])
 
 # Skeleton support.


### PR DESCRIPTION
Hi all,

There is quite some demand to provide the users with more freedom to customize the error messages.  There's also demand for us to stop double-quoting the token names in the table of the symbol names.  For instance in Bison's own parser we have

``` C
static const char *const yytname[] =
{
  "\"end of file\"", "error", "$undefined", "\"string\"", "\"%token\"",
  "\"%nterm\"", "\"%type\"", "\"%destructor\"", "\"%printer\"",
  "\"%left\"", "\"%right\"", "\"%nonassoc\"", "\"%precedence\"",
  "\"%prec\"", "\"%dprec\"", "\"%merge\"", "\"%code\"",
  "\"%default-prec\"", "\"%define\"", "\"%defines\"", "\"%error-verbose\"",
  "\"%expect\"", "\"%expect-rr\"", "\"%<flag>\"", "\"%file-prefix\"",
  "\"%glr-parser\"", "\"%initial-action\"", "\"%language\"",
  "\"%name-prefix\"", "\"%no-default-prec\"", "\"%no-lines\"",
  "\"%nondeterministic-parser\"", "\"%output\"", "\"%pure-parser\"",
  "\"%require\"", "\"%skeleton\"", "\"%start\"", "\"%token-table\"",
  "\"%verbose\"", "\"%yacc\"", "\"{...}\"", "\"%?{...}\"",
  "\"[identifier]\"", "\"character literal\"", "\":\"", "\"epilogue\"",
  "\"=\"", "\"identifier\"", "\"identifier:\"", "\"%%\"", "\"|\"",
  "\"%{...%}\"", "\";\"", "\"<tag>\"", "\"<*>\"", "\"<>\"", "\"integer\"",
  "\"%param\"", "\"%union\"", "\"%empty\"", "$accept", "input",
  "prologue_declarations", "prologue_declaration", "$@1", "params",
  "grammar_declaration", "code_props_type", "union_name",
  "symbol_declaration", "$@2", "$@3", "precedence_declarator", "tag.opt",
  "generic_symlist", "generic_symlist_item", "tag", "nterm_decls",
  "token_decls", "token_decl.1", "token_decl", "int.opt",
  "token_decls_for_prec", "token_decl_for_prec.1", "token_decl_for_prec",
  "symbol_decls", "symbol_decl.1", "grammar",
  "rules_or_grammar_declaration", "rules", "$@4", "rhses.1", "rhs",
  "named_ref.opt", "variable", "value", "id", "id_colon", "symbol",
  "string_as_id", "string_as_id.opt", "epilogue.opt", YY_NULLPTR
};
```

This double-escaping wrecks non-ASCII string literals, such as mathematical symbols written in UTF-8.  It also is a problem when you want to translate your symbols.

About one year ago I made a first attempt to address this: https://lists.gnu.org/r/bison-patches/2018-12/msg00088.html.  That series of patches completely changed the semantics of yytname (by removing this double-quotation).  I was quite happy with the result (I liked a lot the fact that there was just one implementation, not a host of alternatives, as that's the kind of things that make Bison hard to maintain).  I thought we were done, but there were a few problems.

One severe issue brought to my attention by Rici Lake (unfortunately privately, although he had written a very nice and detailed mail with all the details) is that this would break several existing parsers that expect yytname to be this way.  For instance he pointed to

https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libksba.git;a=blob;f=src/asn1-parse.y;h=5bff15cd8db64786f7c9e2ef000aeddd583cfdc0;hb=HEAD#l856

currently not responding, but the code is:

``` C
for (k = 0; k < YYNTOKENS; k++)
  {
    if (yytname[k] && yytname[k][0] == '\"'
        && !strncmp (yytname[k] + 1, string, len)
        && yytname[k][len + 1] == '\"' && !yytname[k][len + 2])
      return yytoknum[k];
  }
```

While I was okay that my changes would modify some error messages of some parsers, I did not want to break parsers.  Note that the core problem here is that some people use yytname to write their scanners. In other words, they use the string literal not as a means to customize the error messages, but to encode in some way their scanner.

We cannot satisfy both needs (better error messages and helping the definition of the scanner) at the same time.  I fully support the use of string literals for better error messages, and will not help to use them for the scanner.  I will pay attention not to break existing code, but I will not make any efforts to make it easier, nor to be portable across skeletons (in the future though, Bison will help these users, but by a totally different means).

I looked at how people use yytnamerr on GitHub (see at the end of this message) and I would summarize that:

- some users "fight" the double quotation there

- some users want to translate the token names

- some users want to customize their error messages and try to shoehorn that into yytnamerr.  The example of PHP is particularly enlightening

I think we can satisfy everybody by offering alternatives to "%define parse.error verbose".

With "%define parse.error rich" (for lack of a better idea, suggestions most welcome), you get something equivalent to 'verbose' but (i) there is no double quotation, (ii) there is support for symbol translation (as in https://lists.gnu.org/r/bison-patches/2018-12/msg00088.html).  This would _not_ support yytnamerr.

With "%define parse.error custom", the user must define the yyreport_syntax_error function, which is fully responsible to emit the syntax error message.  In the branch yyreport_syntax_error (see https://github.com/akimd/bison/pull/16), the example looks like this:

``` C
int
yyreport_syntax_error (const yysyntax_error_context_t *ctx)
{
  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 10 };
  /* Arguments of yyformat: reported tokens (one for the "unexpected",
     one per "expected"). */
  char const *arg[YYERROR_VERBOSE_ARGS_MAXIMUM];
  int n = yysyntax_error_arguments (ctx, arg, sizeof arg / sizeof *arg);
  if (n == -2)
    return 2;
  fprintf (stderr, "SYNTAX ERROR on token [%s]", arg[0]);
  if (1 < n)
    {
      fprintf (stderr, " (expected:");
      for (int i = 1; i < n; ++i)
        fprintf (stderr, " [%s]", arg[i]);
      fprintf (stderr, ")");
    }
  fprintf (stderr, "\n");
  return 0;
}
```

Again, this would not use yytnamerr; it's up to the user to implement and call whatever transformation she wants on the error message.  And there would be no double quotation in yytname.

Chistian made a strong case in favor of what he called "push" API rather than pull:

May 11th 2019, Christian Schoenebeck <schoenebeck@crudebyte.com>
(https://lists.gnu.org/r/help-bison/2019-05/msg00041.html):

> My old concerns still apply, that is I still find a push design (that is you call Bison API functions you need explicitly in your yyerror() implementation to get just the information you need for the error message) more appropriate, flexible, powerful and API stable than a pull design (where you would get a predefined list of information passed to your yyerror_whatever() implementation; like eat it or leave it).
>
> The push design has various advantages. E.g. Bison can easily be extended with new API functions if somebody needs another information, without breaking the previous API and people's existing yyerror() implementations. No matter what kind of arguments Bison would pass to that suggested yyerror_*() function today, I am sure later on people would ask about different information to be provided by Bison as well, or in a different way. Some of them might even be exotic from your point of view, but legitimate for certain use cases, some might become replaced & deprecated, etc. Plus developers could duplicate and modify the parser state without touching the current state to see potential future information, etc.

I think he is right, hence the call to yysyntax_error_arguments which returns the list of expected/unexpected tokens.

I can't make up my mind on whether returning the list of expected tokens as strings (as exemplified above), or simply as their symbol numbers.  Symbol numbers are more efficient, yet they are the *internal* symbol numbers, not the ones the user is exposed to.

I'm not sure I really want the unexpected token to be in the same array.  Maybe some day we would like to have $undefined have a string semantic value, where we would write the unexpected string:

```
$ echo "1+&" | ./_build/g9d/examples/c/calc/calc
SYNTAX ERROR on string [&] (expected: ["number"] ['('])
```

would look better than

```
$ echo "1+&" | ./_build/g9d/examples/c/calc/calc
SYNTAX ERROR on token [$undefined] (expected: ["number"] ['('])
```

If you are familiar with the current implementation of 'verbose' error reporting in yacc.c, you'll see that you cannot emulate it with the custom API I propose.  That's because the 'verbose' implementation goes into a lot of troubles so that the error message is built and stored in yyparse's stack frame (using alloca).  That requires a two step calling convention, where first one would first ask "how much space do I need for the error message" and a last one is "I allocated this much space here, please strcpy the error message here".  This is too complex, I don't think we should support such a complex protocol.



I also plan to get rid of YYERROR_VERBOSE.  Juggling with CPP and M4 at the same time is a nightmare.  YYERROR_VERBOSE was deprecated looong ago (Bison 2.6, 2012-07-19, claims that's deprecated since 1.875 https://git.savannah.gnu.org/cgit/bison.git/commit/NEWS?id=258cddbc3).


I would really appreciate comments on this proposal.  Sorry for making it so long.

Cheers!


# Examples of custom error messages

## hayate891/linuxsampler -- Parser for NKSP real-time instrument script language

They have single quotes in their string literals, yet they don't want the outer quotes (which are not removed by the default yytnamerr if there are single quotes).  IOW, would not be needed with my changes.

https://github.com/hayate891/linuxsampler/blob/831838989ea8066d3875057e84e7585a1fec4160/linuxsampler/trunk/src/scriptvm/parser.y#L806
``` C
/// Custom implementation of yytnamerr() to ensure quotation is always stripped from token names before printing them to error messages.
int InstrScript_tnamerr(char* yyres, const char* yystr) {
 if (*yystr == '"') {
     int yyn = 0;
     char const *yyp = yystr;
     for (;;)
       switch (*++yyp)
         {
/*
         case '\'':
         case ',':
           goto do_not_strip_quotes;
         case '\\':
           if (*++yyp != '\\')
             goto do_not_strip_quotes;
*/
           /* Fall through.  */
         default:
           if (yyres)
             yyres[yyn] = *yyp;
           yyn++;
           break;

         case '"':
           if (yyres)
             yyres[yyn] = '\0';
           return yyn;
         }
/*
   do_not_strip_quotes: ;
*/
   }

 if (! yyres)
   return (int) yystrlen (yystr);

 return int( yystpcpy (yyres, yystr) - yyres );
}
```


## Ortelius maps your microservice configurations with their relationships to the application that use them

https://github.com/ortelius/ortelius/blob/3c23d26b34d88b5e2398d341b5c9a2a9cd00a525/dmengine/dmapi/dm.y#L342

Display literal tokens with quotes around them (e.g., as [unexpected "action"], not as [unexpected "\"action\""].

Would not be needed with straight display.

``` C
%token <bval> T_BOOL	"boolean value"
%token <ival> NUM	"integer value"
%token <str> STR STR2	"string literal"
%token <str> IDENT	"identifier"
%token <str> DOLIDENT	"$identifier"
%token T_ACTION 	"\"action\""
%token T_BREAK 		"\"break\""
%token T_CASE		"\"case\""
%token T_CATCH		"\"catch\""
```

```
case '\\':
	++yyp;
	/* RHT mod - allow double-quotes to be escaped */
	if((*yyp != '\\') && (*yyp != '"')) {
		goto do_not_strip_quotes;
	}
```


## PHP

https://github.com/php/php-src/blob/e1559b51cdde65400434653c55790279a15475d5/Zend/zend_language_parser.y#L1320

``` C
%token <ast> T_LNUMBER   "integer number (T_LNUMBER)"
%token <ast> T_DNUMBER   "floating-point number (T_DNUMBER)"
%token <ast> T_STRING    "identifier (T_STRING)"
%token <ast> T_VARIABLE  "variable (T_VARIABLE)"
%token <ast> T_INLINE_HTML
%token <ast> T_ENCAPSED_AND_WHITESPACE  "quoted-string and whitespace (T_ENCAPSED_AND_WHITESPACE)"
%token <ast> T_CONSTANT_ENCAPSED_STRING "quoted-string (T_CONSTANT_ENCAPSED_STRING)"
%token <ast> T_STRING_VARNAME "variable name (T_STRING_VARNAME)"
%token <ast> T_NUM_STRING "number (T_NUM_STRING)"
```

They maintain state between the different calls to yytname to know whether its the unexpected token, or one of the expected.  To this end they use `CG(parse_error)`, changed in yytnamerr.

https://github.com/php/php-src/blob/2dd2dcaf9c8bcdda9c687660da887c5fddeb7448/Zend/zend_globals_macros.h#L34
```
## define CG(v) (compiler_globals.v)
```

``` C
/* Copy to YYRES the contents of YYSTR after stripping away unnecessary
  quotes and backslashes, so that it's suitable for yyerror.  The
  heuristic is that double-quoting is unnecessary unless the string
  contains an apostrophe, a comma, or backslash (other than
  backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
  null, do not copy; instead, return the length of what the result
  would have been.  */
static YYSIZE_T zend_yytnamerr(char *yyres, const char *yystr)
{
	/* CG(parse_error) states:
	 * 0 => yyres = NULL, yystr is the unexpected token
	 * 1 => yyres = NULL, yystr is one of the expected tokens
	 * 2 => yyres != NULL, yystr is the unexpected token
	 * 3 => yyres != NULL, yystr is one of the expected tokens
	 */
	if (yyres && CG(parse_error) < 2) {
		CG(parse_error) = 2;
	}

	if (CG(parse_error) % 2 == 0) {
		/* The unexpected token */
		char buffer[120];
		const unsigned char *end, *str, *tok1 = NULL, *tok2 = NULL;
		unsigned int len = 0, toklen = 0, yystr_len;

		CG(parse_error)++;

		if (LANG_SCNG(yy_text)[0] == 0 &&
			LANG_SCNG(yy_leng) == 1 &&
			strcmp(yystr, "\"end of file\"") == 0) {
			if (yyres) {
				yystpcpy(yyres, "end of file");
			}
			return sizeof("end of file")-1;
		}

		str = LANG_SCNG(yy_text);
		end = memchr(str, '\n', LANG_SCNG(yy_leng));
		yystr_len = (unsigned int)yystrlen(yystr);

		if ((tok1 = memchr(yystr, '(', yystr_len)) != NULL
			&& (tok2 = zend_memrchr(yystr, ')', yystr_len)) != NULL) {
			toklen = (tok2 - tok1) + 1;
		} else {
			tok1 = tok2 = NULL;
			toklen = 0;
		}

		if (end == NULL) {
			len = LANG_SCNG(yy_leng) > 30 ? 30 : LANG_SCNG(yy_leng);
		} else {
			len = (end - str) > 30 ? 30 : (end - str);
		}
		if (yyres) {
			if (toklen) {
				snprintf(buffer, sizeof(buffer), "'%.*s' %.*s", len, str, toklen, tok1);
			} else {
				snprintf(buffer, sizeof(buffer), "'%.*s'", len, str);
			}
			yystpcpy(yyres, buffer);
		}
		return len + (toklen ? toklen + 1 : 0) + 2;
	}

	/* One of the expected tokens */
	if (!yyres) {
		return yystrlen(yystr) - (*yystr == '"' ? 2 : 0);
	}

	if (*yystr == '"') {
		YYSIZE_T yyn = 0;
		const char *yyp = yystr;

		for (; *++yyp != '"'; ++yyn) {
			yyres[yyn] = *yyp;
		}
		yyres[yyn] = '\0';
		return yyn;
	}
	yystpcpy(yyres, yystr);
	return strlen(yystr);
}
```

GC(parse_error) is reset when the error message is reported:

https://github.com/php/php-src/blob/a40a69fdd058cdcb7da5d4527ea6c7dd261417b7/Zend/zend.c#L1115
``` C
ZEND_COLD void zenderror(const char *error) /* {{{ */
{
	CG(parse_error) = 0;

	if (EG(exception)) {
		/* An exception was thrown in the lexer, don't throw another in the parser. */
		return;
	}

	zend_throw_exception(zend_ce_parse_error, error, 0);
}
/* }}} */

```


## PolishReadabilityChecker

They want i18n.  I don't see where the other tokens are defined though.

https://github.com/stasiekz/PolishReadabilityChecker/blob/86ec1caec23352ac170dc33e12de02a6ce47c044/third_party/corpus2/poliqarp-library/sakura/parser.y#L55

``` C
static size_t yytnamerr(char *yyres, const char *yystr)
{
  const char *translation = _(yystr);
  size_t length = strlen(translation);
  if (yyres != NULL)
     strcpy(yyres, translation);
  return length;
}
#if 0
  M_("$undefined");
  M_("$end");
#endif
```



## Daruma BASIC for Raspberry Pi and Mac OS X

They want I18n.

https://github.com/toshinagata/darumabasic/blob/3979d68493eceafcd4cbc6410d7d52fbe6b8c9ba/common/transmessage.c

``` C
const char *err_msg[] = {
	/* BS_M_ONLY_ONE_DO_COND */
	"only one WHILE/UNTIL condition may appear with DO or LOOP keyword",
	
	/* BS_M_UNDEF_SYMBOL */
	"undefined symbol %s",
```

```
const char *translated_err_msg[] = {
	/* BS_M_ONLY_ONE_DO_COND */
	"DO...LOOPのWHILE/UNTIL条件は一つまでです",
	
	/* BS_M_UNDEF_SYMBOL */
	"%sは未定義です",
	
```
``` C
unsigned int
my_yytnamerr(char *yyres, const char *yystr)
{
	/*  This is a patch to remove 'BS_' from the token name  */
	if (strncmp(yystr, "BS_", 3) == 0)
		yystr += 3;
	/*  End patch  */
```


https://github.com/toshinagata/darumabasic/blob/3979d68493eceafcd4cbc6410d7d52fbe6b8c9ba/common/grammar.y#L24
``` C
/*  Reserved words  */
%token BS_IF BS_THEN BS_ELSE BS_ELSEIF BS_ENDIF
%token BS_DO BS_WHILE BS_UNTIL BS_LOOP
```


## Intel SPMD Program Compiler
https://github.com/ispc/ispc/blob/0198f9f8e3b64716e65e56a3861972c71c6c6019/src/parse.yy#L2092

yytnamerr starts with an addition to be able to rename some of the tokens.  Otherwise, back to the default implementation.

This is C++, yet they use yacc.c.

``` C
static int
lYYTNameErr (char *yyres, const char *yystr)
{
 extern std::map<std::string, std::string> tokenNameRemap;
 Assert(tokenNameRemap.size() > 0);
 if (tokenNameRemap.find(yystr) != tokenNameRemap.end()) {
     std::string n = tokenNameRemap[yystr];
     if (yyres == NULL)
         return n.size();
     else
         return yystpcpy(yyres, n.c_str()) - yyres;
 }

 if (*yystr == '"')
   {
     YYSIZE_T yyn = 0;
     char const *yyp = yystr;

     for (;;)
       switch (*++yyp)
         {
         case '\'':
         case ',':
           goto do_not_strip_quotes;

         case '\\':
           if (*++yyp != '\\')
             goto do_not_strip_quotes;
           /* Fall through.  */
         default:
           if (yyres)
             yyres[yyn] = *yyp;
           yyn++;
           break;

         case '"':
           if (yyres)
             yyres[yyn] = '\0';
           return yyn;
         }
   do_not_strip_quotes: ;
   }

 if (! yyres)
   return yystrlen (yystr);

 return yystpcpy (yyres, yystr) - yyres;
}
```


https://github.com/ispc/ispc/blob/017e80e7c0a4187b44e37aed3c235520fccaf088/src/lex.ll#L98
``` C
void ParserInit() {
   tokenToName[TOKEN_ASSERT] = "assert";
   tokenToName[TOKEN_BOOL] = "bool";
   tokenToName[TOKEN_BREAK] = "break";
   tokenToName[TOKEN_CASE] = "case";
   tokenToName[TOKEN_CDO] = "cdo";
   tokenToName[TOKEN_CFOR] = "cfor";
   tokenToName[TOKEN_CIF] = "cif";
```

https://github.com/ispc/ispc/blob/017e80e7c0a4187b44e37aed3c235520fccaf088/src/lex.ll#L218
``` C
   tokenNameRemap["TOKEN_ASSERT"] = "\'assert\'";
   tokenNameRemap["TOKEN_BOOL"] = "\'bool\'";
   tokenNameRemap["TOKEN_BREAK"] = "\'break\'";
   tokenNameRemap["TOKEN_CASE"] = "\'case\'";
   tokenNameRemap["TOKEN_CDO"] = "\'cdo\'";
   tokenNameRemap["TOKEN_CFOR"] = "\'cfor\'";
```


## Ruby

https://github.com/ruby/ruby/blob/0c2d731ef210c9121e2a97cc5b0d7594a80389f3/parse.y#L12687


``` C
/*
* strip enclosing double-quotes, same as the default yytnamerr except
* for that single-quotes matching back-quotes do not stop stripping.
*
*  "\"`class' keyword\"" => "`class' keyword"
*/
RUBY_FUNC_EXPORTED size_t
rb_yytnamerr(struct parser_params *p, char *yyres, const char *yystr)
{
   YYUSE(p);
   if (*yystr == '"') {
	size_t yyn = 0, bquote = 0;
	const char *yyp = yystr;

```
