### PR TITLE
Remove support for YYERROR_VERBOSE

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,17 @@ GNU Bison NEWS
 
 * Noteworthy changes in release ?.? (????-??-??) [?]
 
+** Backward incompatible changes
+
+  TL;DR: replace "#define YYERROR_VERBOSE 1" by "%define parse.error verbose".
+
+  The YYERROR_VERBOSE macro is no longer supported; the parsers that still
+  depend on it will now produce Yacc-like error messages (just "syntax
+  error").  It was superseded by the "%error-verbose" directive in Bison
+  1.875 (2003-01-01).  Bison 2.6 (2012-07-19) clearly announced that support
+  for YYERROR_VERBOSE would be removed.  Note that since Bison 3.0
+  (2013-07-25), "%error-verbose" is deprecated in favor of "%define
+  parse.error verbose".
 
 * Noteworthy changes in release 3.5 (2019-12-11) [stable]
 

--- a/data/skeletons/glr.c
+++ b/data/skeletons/glr.c
@@ -241,14 +241,6 @@ b4_copyright([Skeleton implementation for Bison GLR parsers in C],
 ]b4_defines_if([[#include "@basename(]b4_spec_header_file[@)"]],
                [b4_shared_declarations])[
 
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE ]b4_error_verbose_if([1], [0])[
-#endif
-
 /* Default (constant) value used for initialization for null
    right-hand sides.  Unlike the standard yacc.c template, here we set
    the default value of $$ to a zeroed-out value.  Since the default
@@ -376,7 +368,7 @@ static const ]b4_int_type_for([b4_rline])[ yyrline[] =
 };
 #endif
 
-#if ]b4_api_PREFIX[DEBUG || YYERROR_VERBOSE || ]b4_token_table_flag[
+#if ]b4_error_verbose_if([[1]], [b4_api_PREFIX[DEBUG || ]b4_token_table_flag])[
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
@@ -567,9 +559,8 @@ static void yypdumpstack (struct yyGLRStack* yystackp)
 #endif
 
 
-#if YYERROR_VERBOSE
-
-# ifndef yystpcpy
+]m4_case(b4_percent_define_get([parse.error]), [verbose],
+[[# ifndef yystpcpy
 #  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
 #   define yystpcpy stpcpy
 #  else
@@ -639,8 +630,7 @@ yytnamerr (char *yyres, const char *yystr)
     return YY_CAST (ptrdiff_t, strlen (yystr));
 }
 # endif
-
-#endif /* !YYERROR_VERBOSE */
+]])[
 
 /** State numbers. */
 typedef int yyStateNum;
@@ -756,7 +746,7 @@ yyMemoryExhausted (yyGLRStack* yystackp)
   YYLONGJMP (yystackp->yyexception_buffer, 2);
 }
 
-#if ]b4_api_PREFIX[DEBUG || YYERROR_VERBOSE
+#if ]b4_error_verbose_if([[1]], [b4_api_PREFIX[DEBUG]])[
 /** A printable representation of TOKEN.  */
 static inline const char*
 yytokenName (yySymbol yytoken)
@@ -2075,10 +2065,11 @@ yyreportSyntaxError (yyGLRStack* yystackp]b4_user_formals[)
 {
   if (yystackp->yyerrState != 0)
     return;
-#if ! YYERROR_VERBOSE
-  yyerror (]b4_lyyerror_args[YY_("syntax error"));
-#else
-  {
+]m4_case(b4_percent_define_get([parse.error]),
+         [simple],
+[[  yyerror (]b4_lyyerror_args[YY_("syntax error"));]],
+         [verbose],
+[[  {
   yySymbol yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
   yybool yysize_overflow = yyfalse;
   char* yymsg = YY_NULLPTR;
@@ -2203,8 +2194,7 @@ yyreportSyntaxError (yyGLRStack* yystackp]b4_user_formals[)
       yyerror (]b4_lyyerror_args[YY_("syntax error"));
       yyMemoryExhausted (yystackp);
     }
-  }
-#endif /* YYERROR_VERBOSE */
+  }]])[
   yynerrs += 1;
 }
 

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -1769,16 +1769,16 @@ yyerrlab:
             if (yymsg != yymsgbuf)
               YYSTACK_FREE (yymsg);
             yymsg = YY_CAST (char *, YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
-            if (!yymsg)
+            if (yymsg)
+              {
+                yysyntax_error_status = YYSYNTAX_ERROR;
+                yymsgp = yymsg;
+              }
+            else
               {
                 yymsg = yymsgbuf;
                 yymsg_alloc = sizeof yymsgbuf;
                 yysyntax_error_status = 2;
-              }
-            else
-              {
-                yysyntax_error_status = YYSYNTAX_ERROR;
-                yymsgp = yymsg;
               }
           }
         yyerror (]b4_yyerror_args[yymsgp);

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -348,14 +348,6 @@ m4_if(b4_api_prefix, [yy], [],
 ]b4_cast_define[
 ]b4_null_define[
 
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE ]b4_error_verbose_if([1], [0])[
-#endif
-
 ]b4_header_include_if([[#include ]b4_percent_define_get([[api.header.include]])],
                       [m4_ifval(m4_quote(b4_spec_header_file),
                                 [/* Use api.header.include to #include this header
@@ -437,7 +429,7 @@ typedef int yy_state_fast_t;
 ]],
 [[#define YY_ASSERT(E) ((void) (0 && (E)))]])[
 
-#if ]b4_lac_if([[1]], [[! defined yyoverflow || YYERROR_VERBOSE]])[
+#if ]b4_lac_if([[1]], [b4_error_verbose_if([[1]], [[!defined yyoverflow]])])[
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */]dnl
 b4_push_if([], [b4_lac_if([], [[
@@ -504,8 +496,7 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 #  endif
 # endif]b4_lac_if([[
 # define YYCOPY_NEEDED 1]])[
-#endif]b4_lac_if([], [[ /* ! defined yyoverflow || YYERROR_VERBOSE */]])[
-
+#endif]b4_lac_if([], [b4_error_verbose_if([], [[/* !defined yyoverflow */]])])[
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
@@ -611,7 +602,7 @@ static const ]b4_int_type_for([b4_translate])[ yytranslate[] =
      [[YYRLINE[YYN] -- Source line where rule number YYN was defined.]])[
 #endif
 
-#if ]b4_api_PREFIX[DEBUG || YYERROR_VERBOSE || ]b4_token_table_flag[
+#if ]b4_error_verbose_if([[1]], [b4_api_PREFIX[DEBUG || ]b4_token_table_flag])[
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
@@ -1039,9 +1030,8 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
 }]])[
 
 
-#if YYERROR_VERBOSE
-
-# ifndef yystrlen
+]m4_case(b4_percent_define_get([parse.error]), [verbose],
+[[# ifndef yystrlen
 #  if defined __GLIBC__ && defined _STRING_H
 #   define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
 #  else
@@ -1287,7 +1277,7 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
   }
   return 0;
 }
-#endif /* YYERROR_VERBOSE */
+]])[
 
 ]b4_yydestruct_define[
 
@@ -1428,12 +1418,11 @@ b4_function_define([[yyparse]], [[int]], b4_parse_param)[
   YYSTYPE yyval;]b4_locations_if([[
   YYLTYPE yyloc;]])[
 
-#if YYERROR_VERBOSE
-  /* Buffer for error messages, and its allocated size.  */
+]m4_case(b4_percent_define_get([parse.error]), [verbose],
+[[  /* Buffer for error messages, and its allocated size.  */
   char yymsgbuf[128];
   char *yymsg = yymsgbuf;
-  YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
-#endif
+  YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;]])[
 
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N)]b4_locations_if([, yylsp -= (N)])[)
 
@@ -1750,10 +1739,11 @@ yyerrlab:
   if (!yyerrstatus)
     {
       ++yynerrs;
-#if ! YYERROR_VERBOSE
-      yyerror (]b4_yyerror_args[YY_("syntax error"));
-#else
-# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \]b4_lac_if([[
+]m4_case(b4_percent_define_get([parse.error]),
+         [simple],
+[[      yyerror (]b4_yyerror_args[YY_("syntax error"));]],
+         [verbose],
+[[# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \]b4_lac_if([[
                                         yyesa, &yyes, &yyes_capacity, \]])[
                                         yyssp, yytoken)
       {
@@ -1785,8 +1775,7 @@ yyerrlab:
         if (yysyntax_error_status == 2)
           goto yyexhaustedlab;
       }
-# undef YYSYNTAX_ERROR
-#endif
+# undef YYSYNTAX_ERROR]])[
     }
 
 ]b4_locations_if([[  yyerror_range[1] = yylloc;]])[
@@ -1902,7 +1891,7 @@ yyabortlab:
   goto yyreturn;
 
 
-#if ]b4_lac_if([[1]], [[!defined yyoverflow || YYERROR_VERBOSE]])[
+#if ]b4_lac_if([[1]], [b4_error_verbose_if([[1]], [[!defined yyoverflow]])])[
 /*-------------------------------------------------.
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
@@ -1948,10 +1937,9 @@ yyreturn:
 | yypushreturn -- ask for the next token.  |
 `-----------------------------------------*/
 yypushreturn:]])[
-#if YYERROR_VERBOSE
-  if (yymsg != yymsgbuf)
-    YYSTACK_FREE (yymsg);
-#endif
+]m4_case(b4_percent_define_get([parse.error]), [verbose],
+[[  if (yymsg != yymsgbuf)
+    YYSTACK_FREE (yymsg);]])[
   return yyresult;
 }
 ]b4_epilogue[]dnl

--- a/doc/bison.texi
+++ b/doc/bison.texi
@@ -14158,15 +14158,6 @@ User-supplied function to be called by @code{yyparse} on error.
 @xref{Error Reporting, ,The Error Reporting Function @code{yyerror}}.
 @end deffn
 
-@deffn {Macro} YYERROR_VERBOSE
-An obsolete macro used in the @file{yacc.c} skeleton, that you define
-with @code{#define} in the prologue to request verbose, specific error
-message strings when @code{yyerror} is called.  It doesn't matter what
-definition you use for @code{YYERROR_VERBOSE}, just whether you define
-it.  Using @samp{%define parse.error verbose} is preferred
-(@pxref{Error Reporting, ,The Error Reporting Function @code{yyerror}}).
-@end deffn
-
 @deffn {Macro} YYFPRINTF
 Macro used to output run-time traces in C.
 @xref{Enabling Traces}.

--- a/tests/conflicts.at
+++ b/tests/conflicts.at
@@ -309,7 +309,6 @@ AT_DATA_GRAMMAR([input.y],
 #include <string.h>
 #include <assert.h>
 
-#define YYERROR_VERBOSE 1
 ]AT_YYERROR_DEFINE[
 /* The current argument. */
 static const char *input;
@@ -323,6 +322,8 @@ yylex (void)
 }
 
 %}
+
+%define parse.error verbose
 
 %nonassoc '<' '>'
 


### PR DESCRIPTION
Maintaining support for YYERROR_VERBOSE while providing more features
for syntax error generation is too painful, so YYERROR_VERBOSE is no
longer supported.  This is not exactly a breaking change: the parsers
that still depend on it will now produce Yacc-like error messages
(just "syntax error"), but they remain functional.

YYERROR_VERBOSE was superseded by the "%error-verbose" directive in
Bison 1.875 (2003-01-01).  Bison 2.6 (2012-07-19) clearly announced
that support for YYERROR_VERBOSE would be removed.

Since Bison 3.0 (2013-07-25), "%error-verbose" is deprecated in favor
of "%define parse.error verbose".
