### PR TITLE
Better error messages

### DIFF
--- a/data/skeletons/bison.m4
+++ b/data/skeletons/bison.m4
@@ -1018,16 +1018,17 @@ m4_define([b4_bison_locations_if],
 
 # b4_error_verbose_if([IF-ERRORS-ARE-VERBOSE], [IF-NOT])
 # ------------------------------------------------------
-# Map %define parse.error "(custom|simple|verbose)" to b4_error_verbose_if and
-# b4_error_verbose_flag.
+# Map %define parse.error "(custom|detailed|simple|verbose)" to
+# b4_error_verbose_if and b4_error_verbose_flag.
 b4_percent_define_default([[parse.error]], [[simple]])
 b4_percent_define_check_values([[[[parse.error]],
-                                 [[custom]], [[simple]], [[verbose]]]])
+                                 [[custom]], [[detailed]], [[simple]], [[verbose]]]])
 m4_define([b4_error_verbose_flag],
           [m4_case(b4_percent_define_get([[parse.error]]),
-                   [custom],  [[1]],
-                   [simple],  [[0]],
-                   [verbose], [[1]])])
+                   [custom],   [[1]],
+                   [detailed], [[1]],
+                   [simple],   [[0]],
+                   [verbose],  [[1]])])
 b4_define_flag_if([error_verbose])
 
 # yytoken_table is needed to support verbose errors.

--- a/data/skeletons/c.m4
+++ b/data/skeletons/c.m4
@@ -662,7 +662,7 @@ b4_locations_if([, [[YYLTYPE const * const yylocationp], [yylocationp]]])[]dnl
 m4_ifset([b4_parse_param], [, b4_parse_param]))[
 {
   YYFPRINTF (yyo, "%s %s (",
-             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
+             yytype < YYNTOKENS ? "token" : "nterm", yysymbol_name (yytype));
 
 ]b4_locations_if([  YY_LOCATION_PRINT (yyo, *yylocationp);
   YYFPRINTF (yyo, ": ");

--- a/data/skeletons/glr.c
+++ b/data/skeletons/glr.c
@@ -461,62 +461,6 @@ typedef enum { yyok, yyaccept, yyabort, yyerr } YYRESULTTAG;
       return yychk_flag;                        \
   } while (0)
 
-#if ]b4_api_PREFIX[DEBUG
-
-# ifndef YYFPRINTF
-#  define YYFPRINTF fprintf
-# endif
-
-# define YY_FPRINTF                             \
-  YY_IGNORE_USELESS_CAST_BEGIN YY_FPRINTF_
-
-# define YY_FPRINTF_(Args)                      \
-  do {                                          \
-    YYFPRINTF Args;                             \
-    YY_IGNORE_USELESS_CAST_END                  \
-  } while (0)
-
-# define YY_DPRINTF                             \
-  YY_IGNORE_USELESS_CAST_BEGIN YY_DPRINTF_
-
-# define YY_DPRINTF_(Args)                      \
-  do {                                          \
-    if (yydebug)                                \
-      YYFPRINTF Args;                           \
-    YY_IGNORE_USELESS_CAST_END                  \
-  } while (0)
-
-]b4_yy_location_print_define[
-
-]b4_yy_symbol_print_define[
-
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                  \
-  do {                                                                  \
-    if (yydebug)                                                        \
-      {                                                                 \
-        YY_FPRINTF ((stderr, "%s ", Title));                            \
-        yy_symbol_print (stderr, Type, Value]b4_locuser_args([Location])[);        \
-        YY_FPRINTF ((stderr, "\n"));                                    \
-      }                                                                 \
-  } while (0)
-
-/* Nonzero means print parse trace.  It is left uninitialized so that
-   multiple parsers can coexist.  */
-int yydebug;
-
-struct yyGLRStack;
-static void yypstack (struct yyGLRStack* yystackp, ptrdiff_t yyk)
-  YY_ATTRIBUTE_UNUSED;
-static void yypdumpstack (struct yyGLRStack* yystackp)
-  YY_ATTRIBUTE_UNUSED;
-
-#else /* !]b4_api_PREFIX[DEBUG */
-
-# define YY_DPRINTF(Args) do {} while (yyfalse)
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
-
-#endif /* !]b4_api_PREFIX[DEBUG */
-
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
 #ifndef YYINITDEPTH
 # define YYINITDEPTH ]b4_stack_depth_init[
@@ -754,6 +698,62 @@ yytokenName (yySymbol yytoken)
   return yytoken == YYEMPTY ? "" : yytname[yytoken];
 }
 #endif
+
+#if ]b4_api_PREFIX[DEBUG
+
+# ifndef YYFPRINTF
+#  define YYFPRINTF fprintf
+# endif
+
+# define YY_FPRINTF                             \
+  YY_IGNORE_USELESS_CAST_BEGIN YY_FPRINTF_
+
+# define YY_FPRINTF_(Args)                      \
+  do {                                          \
+    YYFPRINTF Args;                             \
+    YY_IGNORE_USELESS_CAST_END                  \
+  } while (0)
+
+# define YY_DPRINTF                             \
+  YY_IGNORE_USELESS_CAST_BEGIN YY_DPRINTF_
+
+# define YY_DPRINTF_(Args)                      \
+  do {                                          \
+    if (yydebug)                                \
+      YYFPRINTF Args;                           \
+    YY_IGNORE_USELESS_CAST_END                  \
+  } while (0)
+
+]b4_yy_location_print_define[
+
+]b4_yy_symbol_print_define[
+
+# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                  \
+  do {                                                                  \
+    if (yydebug)                                                        \
+      {                                                                 \
+        YY_FPRINTF ((stderr, "%s ", Title));                            \
+        yy_symbol_print (stderr, Type, Value]b4_locuser_args([Location])[);        \
+        YY_FPRINTF ((stderr, "\n"));                                    \
+      }                                                                 \
+  } while (0)
+
+/* Nonzero means print parse trace.  It is left uninitialized so that
+   multiple parsers can coexist.  */
+int yydebug;
+
+struct yyGLRStack;
+static void yypstack (struct yyGLRStack* yystackp, ptrdiff_t yyk)
+  YY_ATTRIBUTE_UNUSED;
+static void yypdumpstack (struct yyGLRStack* yystackp)
+  YY_ATTRIBUTE_UNUSED;
+
+#else /* !]b4_api_PREFIX[DEBUG */
+
+# define YY_DPRINTF(Args) do {} while (yyfalse)
+# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
+
+#endif /* !]b4_api_PREFIX[DEBUG */
 
 /** Fill in YYVSP[YYLOW1 .. YYLOW0-1] from the chain of states starting
  *  at YYVSP[YYLOW0].yystate.yypred.  Leaves YYVSP[YYLOW1].yystate.yypred

--- a/data/skeletons/glr.c
+++ b/data/skeletons/glr.c
@@ -693,7 +693,7 @@ yyMemoryExhausted (yyGLRStack* yystackp)
 #if ]b4_error_verbose_if([[1]], [b4_api_PREFIX[DEBUG]])[
 /** A printable representation of TOKEN.  */
 static inline const char*
-yytokenName (yySymbol yytoken)
+yysymbol_name (yySymbol yytoken)
 {
   return yytoken == YYEMPTY ? "" : yytname[yytoken];
 }
@@ -1738,11 +1738,11 @@ yyreportTree (yySemanticOption* yyx, int yyindent)
 
   if (yyx->yystate->yyposn < yys->yyposn + 1)
     YY_FPRINTF ((stderr, "%*s%s -> <Rule %d, empty>\n",
-                 yyindent, "", yytokenName (yylhsNonterm (yyx->yyrule)),
+                 yyindent, "", yysymbol_name (yylhsNonterm (yyx->yyrule)),
                  yyx->yyrule - 1));
   else
     YY_FPRINTF ((stderr, "%*s%s -> <Rule %d, tokens %ld .. %ld>\n",
-                 yyindent, "", yytokenName (yylhsNonterm (yyx->yyrule)),
+                 yyindent, "", yysymbol_name (yylhsNonterm (yyx->yyrule)),
                  yyx->yyrule - 1, YY_CAST (long, yys->yyposn + 1),
                  YY_CAST (long, yyx->yystate->yyposn)));
   for (yyi = 1; yyi <= yynrhs; yyi += 1)
@@ -1751,10 +1751,10 @@ yyreportTree (yySemanticOption* yyx, int yyindent)
         {
           if (yystates[yyi-1]->yyposn+1 > yystates[yyi]->yyposn)
             YY_FPRINTF ((stderr, "%*s%s <empty>\n", yyindent+2, "",
-                         yytokenName (yystos[yystates[yyi]->yylrState])));
+                         yysymbol_name (yystos[yystates[yyi]->yylrState])));
           else
             YY_FPRINTF ((stderr, "%*s%s <tokens %ld .. %ld>\n", yyindent+2, "",
-                         yytokenName (yystos[yystates[yyi]->yylrState]),
+                         yysymbol_name (yystos[yystates[yyi]->yylrState]),
                          YY_CAST (long, yystates[yyi-1]->yyposn + 1),
                          YY_CAST (long, yystates[yyi]->yyposn)));
         }
@@ -2111,7 +2111,7 @@ yyreportSyntaxError (yyGLRStack* yystackp]b4_user_formals[)
   if (yytoken != YYEMPTY)
     {
       int yyn = yypact[yystackp->yytops.yystates[0]->yylrState];
-      yyarg[yycount++] = yytokenName (yytoken);
+      yyarg[yycount++] = yysymbol_name (yytoken);
       if (!yypact_value_is_default (yyn))
         {
           /* Start YYX at -YYN if negative to avoid negative indexes in
@@ -2131,7 +2131,7 @@ yyreportSyntaxError (yyGLRStack* yystackp]b4_user_formals[)
                     yycount = 1;
                     break;
                   }
-                yyarg[yycount++] = yytokenName (yyx);
+                yyarg[yycount++] = yysymbol_name (yyx);
               }
         }
     }

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -631,8 +631,17 @@ yysymbol_name (int yysymbol)
   static const char *const yy_sname[] =
   {
   ]b4_symbol_names[
+  };]m4_ifdef([b4_translatable], [[
+  /* YYTRANSLATABLE[SYMBOL-NUM] -- Whether YYTNAME[SYMBOL-NUM] is
+     internationalizable.  */
+  static ]b4_int_type_for([b4_translate])[ yytranslatable[] =
+  {
+  ]b4_translatable[
   };
-  return yy_sname[yysymbol];
+  return (yysymbol < YYNTOKENS && yytranslatable[yysymbol]
+          ? _(yy_sname[yysymbol])
+          : yy_sname[yysymbol]);]], [[
+  return yy_sname[yysymbol];]])[
 }]])[
 #endif
 
@@ -1248,7 +1257,6 @@ yytnamerr (char *yyres, const char *yystr)
     {
       YYPTRDIFF_T yyn = 0;
       char const *yyp = yystr;
-
       for (;;)
         switch (*++yyp)
           {

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -603,21 +603,37 @@ static const ]b4_int_type_for([b4_translate])[ yytranslate[] =
 #endif
 
 #if ]b4_error_verbose_if([[1]], [b4_api_PREFIX[DEBUG || ]b4_token_table_flag])[
-/* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (int yysymbol) YY_ATTRIBUTE_UNUSED;
+
+]m4_bmatch(b4_percent_define_get([[parse.error]]),
+           [simple\|verbose],
+[[/* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
   ]b4_tname[
 };
 
-/* The user-facing name of the symbol whose (internal) number is
-   YYSYMBOL.  No bounds checking.  */
-static const char *yysymbol_name (int yysymbol) YY_ATTRIBUTE_UNUSED;
 static const char *
 yysymbol_name (int yysymbol)
 {
   return yytname[yysymbol];
-}
+}]],
+[[/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (int yysymbol) YY_ATTRIBUTE_UNUSED;
+
+static const char *
+yysymbol_name (int yysymbol)
+{
+  static const char *const yy_sname[] =
+  {
+  ]b4_symbol_names[
+  };
+  return yy_sname[yysymbol];
+}]])[
 #endif
 
 # ifdef YYPRINT
@@ -1177,7 +1193,8 @@ yyparse_context_location (const yyparse_context_t *yyctx)
 ]b4_function_declare([yyreport_syntax_error], [static int],
                      [[[const yyparse_context_t *yyctx]], [[yyctx]]],
                      b4_parse_param)],
-         [verbose],
+         [simple],
+[[]],
 [[# ifndef yystrlen
 #  if defined __GLIBC__ && defined _STRING_H
 #   define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
@@ -1214,7 +1231,9 @@ yyparse_context_location (const yyparse_context_t *yyctx)
 #  endif
 # endif
 
-# ifndef yytnamerr
+]m4_case(b4_percent_define_get([[parse.error]]),
+         [verbose],
+[[# ifndef yytnamerr
 /* Copy to YYRES the contents of YYSTR after stripping away unnecessary
    quotes and backslashes, so that it's suitable for yyerror.  The
    heuristic is that double-quoting is unnecessary unless the string
@@ -1264,7 +1283,7 @@ yytnamerr (char *yyres, const char *yystr)
     return yystrlen (yystr);
 }
 # endif
-
+]])[
 
 /* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
    about the unexpected token YYTOKEN for the state stack whose top is
@@ -1319,7 +1338,9 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
     for (yyi = 0; yyi < yycount; ++yyi)
       {
         YYPTRDIFF_T yysize1
-          = yysize + yytnamerr (YY_NULLPTR, yytname[yyarg[yyi]]);
+          = yysize + ]m4_case(b4_percent_define_get([[parse.error]]),
+                              [verbose], [[yytnamerr (YY_NULLPTR, yytname[yyarg[yyi]])]],
+                              [[yystrlen (yysymbol_name (yyarg[yyi]))]]);[
         if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
           yysize = yysize1;
         else
@@ -1344,8 +1365,9 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
     int yyi = 0;
     while ((*yyp = *yyformat) != '\0')
       if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
-        {
-          yyp += yytnamerr (yyp, yytname[yyarg[yyi++]]);
+        {]m4_case(b4_percent_define_get([[parse.error]]), [verbose], [[
+          yyp += yytnamerr (yyp, yytname[yyarg[yyi++]]);]], [[
+          yyp = yystpcpy (yyp, yysymbol_name (yyarg[yyi++]));]])[
           yyformat += 2;
         }
       else
@@ -1499,7 +1521,7 @@ b4_function_define([[yyparse]], [[int]], b4_parse_param)[
   YYSTYPE yyval;]b4_locations_if([[
   YYLTYPE yyloc;]])[
 
-]m4_case(b4_percent_define_get([[parse.error]]), [verbose],
+]m4_bmatch(b4_percent_define_get([[parse.error]]), [detailed\|verbose],
 [[  /* Buffer for error messages, and its allocated size.  */
   char yymsgbuf[128];
   char *yymsg = yymsgbuf;
@@ -1833,7 +1855,6 @@ yyerrlab:
       }]],
          [simple],
 [[      yyerror (]b4_yyerror_args[YY_("syntax error"));]],
-         [verbose],
 [[      {
         char const *yymsgp = YY_("syntax error");
         yyparse_context_t yyctx
@@ -2028,7 +2049,7 @@ yyreturn:
 | yypushreturn -- ask for the next token.  |
 `-----------------------------------------*/
 yypushreturn:]])[
-]m4_case(b4_percent_define_get([[parse.error]]), [verbose],
+]m4_bmatch(b4_percent_define_get([[parse.error]]), [detailed\|verbose],
 [[  if (yymsg != yymsgbuf)
     YYSTACK_FREE (yymsg);]])[
   return yyresult;

--- a/src/output.c
+++ b/src/output.c
@@ -139,13 +139,17 @@ static void
 prepare_symbol_names (char const *muscle_name)
 {
   /* We assume that the table will be output starting at column 2. */
+  const bool quote = STREQ (muscle_name, "tname");
   int j = 2;
   struct quoting_options *qo = clone_quoting_options (0);
   set_quoting_style (qo, c_quoting_style);
   set_quoting_flags (qo, QA_SPLIT_TRIGRAPHS);
   for (int i = 0; i < nsyms; i++)
     {
-      char *cp = quotearg_alloc (symbols[i]->tag, -1, qo);
+      char *cp =
+        symbols[i]->tag[0] == '"' && !quote
+        ? xstrdup (symbols[i]->tag)
+        : quotearg_alloc (symbols[i]->tag, -1, qo);
       /* Width of the next token, including the two quotes, the
          comma and the space.  */
       int width = strlen (cp) + 2;
@@ -192,6 +196,7 @@ prepare_symbols (void)
 
   /* tname -- token names.  */
   prepare_symbol_names ("tname");
+  prepare_symbol_names ("symbol_names");
 
   /* Output YYTOKNUM. */
   {

--- a/src/output.c
+++ b/src/output.c
@@ -206,7 +206,9 @@ prepare_symbol_names (char const *muscle_name)
         : quotearg_alloc (symbols[i]->tag, -1, qo);
       /* Width of the next token, including the two quotes, the
          comma and the space.  */
-      int width = strlen (cp) + 2;
+      int width
+        = strlen (cp) + 2
+        + (!quote && symbols[i]->translatable ? strlen ("N_()") : 0);
 
       if (j + width > 75)
         {
@@ -216,7 +218,11 @@ prepare_symbol_names (char const *muscle_name)
 
       if (i)
         obstack_1grow (&format_obstack, ' ');
+      if (!quote && symbols[i]->translatable)
+        obstack_sgrow (&format_obstack, "N_(");
       obstack_escape (&format_obstack, cp);
+      if (!quote && symbols[i]->translatable)
+        obstack_1grow (&format_obstack, ')');
       free (cp);
       obstack_1grow (&format_obstack, ',');
       j += width;

--- a/src/output.c
+++ b/src/output.c
@@ -132,6 +132,56 @@ string_output (FILE *out, char const *string)
 }
 
 
+/* Store in BUFFER a copy of SRC where trigraphs are escaped, return
+   the size of the result (including the final NUL).  If called with
+   BUFFERSIZE = 0, returns the needed size for BUFFER.  */
+static ptrdiff_t
+escape_trigraphs (char *buffer, ptrdiff_t buffersize, const char *src)
+{
+#define STORE(c)                                \
+  do                                            \
+    {                                           \
+      if (res < buffersize)                     \
+        buffer[res] = (c);                      \
+      ++res;                                    \
+    }                                           \
+  while (0)
+  ptrdiff_t res = 0;
+  for (ptrdiff_t i = 0, len = strlen (src); i < len; ++i)
+    {
+      if (i + 2 < len
+          && src[i] == '?' && src[i+1] == '?')
+        {
+          switch (src[i+2])
+            {
+            case '!': case '\'':
+            case '(': case ')': case '-': case '/':
+            case '<': case '=': case '>':
+              i += 1;
+              STORE ('?');
+              STORE ('"');
+              STORE ('"');
+              STORE ('?');
+              continue;
+            }
+        }
+      STORE (src[i]);
+    }
+  STORE ('\0');
+#undef STORE
+  return res;
+}
+
+/* Same as xstrdup, except that trigraphs are escaped.  */
+static char *
+xescape_trigraphs (const char *src)
+{
+  ptrdiff_t bufsize = escape_trigraphs (NULL, 0, src);
+  char *buf = xcharalloc (bufsize);
+  escape_trigraphs (buf, bufsize, src);
+  return buf;
+}
+
 /* Generate the b4_<MUSCLE_NAME> (e.g., b4_tname) table with the
    symbol names (aka tags). */
 
@@ -148,7 +198,7 @@ prepare_symbol_names (char const *muscle_name)
     {
       char *cp =
         symbols[i]->tag[0] == '"' && !quote
-        ? xstrdup (symbols[i]->tag)
+        ? xescape_trigraphs (symbols[i]->tag)
         : quotearg_alloc (symbols[i]->tag, -1, qo);
       /* Width of the next token, including the two quotes, the
          comma and the space.  */

--- a/src/output.c
+++ b/src/output.c
@@ -50,6 +50,10 @@ static struct obstack format_obstack;
 | result of formatting the FIRST and then TABLE_DATA[BEGIN..END[ (of |
 | TYPE), and to the muscle NAME_max, the max value of the            |
 | TABLE_DATA.                                                        |
+|                                                                    |
+| For the typical case of outputting a complete table from 0, pass   |
+| TABLE[0] as FIRST, and 1 as BEGIN.  For instance                   |
+| muscle_insert_base_table ("pact", base, base[0], 1, nstates);      |
 `-------------------------------------------------------------------*/
 
 
@@ -247,6 +251,26 @@ prepare_symbols (void)
   /* tname -- token names.  */
   prepare_symbol_names ("tname");
   prepare_symbol_names ("symbol_names");
+
+  /* translatable -- whether a token is translatable. */
+  {
+    bool translatable = false;
+    for (int i = 0; i < ntokens; ++i)
+      if (symbols[i]->translatable)
+        {
+          translatable = true;
+          break;
+        }
+    if (translatable)
+      {
+        int *values = xnmalloc (nsyms, sizeof *values);
+        for (int i = 0; i < ntokens; ++i)
+          values[i] = symbols[i]->translatable;
+        muscle_insert_int_table ("translatable", values,
+                                 values[0], 1, ntokens);
+        free (values);
+      }
+  }
 
   /* Output YYTOKNUM. */
   {

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -526,25 +526,26 @@ static const yytype_int16 yyrline[] =
    YYSYMBOL.  No bounds checking.  */
 static const char *yysymbol_name (int yysymbol) YY_ATTRIBUTE_UNUSED;
 
-/* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
-   First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
-static const char *const yytname[] =
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (int yysymbol) YY_ATTRIBUTE_UNUSED;
+
+static const char *
+yysymbol_name (int yysymbol)
 {
-  "\"end of file\"", "error", "$undefined", "\"string\"", "\"%token\"",
-  "\"%nterm\"", "\"%type\"", "\"%destructor\"", "\"%printer\"",
-  "\"%left\"", "\"%right\"", "\"%nonassoc\"", "\"%precedence\"",
-  "\"%prec\"", "\"%dprec\"", "\"%merge\"", "\"%code\"",
-  "\"%default-prec\"", "\"%define\"", "\"%defines\"", "\"%error-verbose\"",
-  "\"%expect\"", "\"%expect-rr\"", "\"%<flag>\"", "\"%file-prefix\"",
-  "\"%glr-parser\"", "\"%initial-action\"", "\"%language\"",
-  "\"%name-prefix\"", "\"%no-default-prec\"", "\"%no-lines\"",
-  "\"%nondeterministic-parser\"", "\"%output\"", "\"%pure-parser\"",
-  "\"%require\"", "\"%skeleton\"", "\"%start\"", "\"%token-table\"",
-  "\"%verbose\"", "\"%yacc\"", "\"{...}\"", "\"%?{...}\"",
-  "\"[identifier]\"", "\"character literal\"", "\":\"", "\"epilogue\"",
-  "\"=\"", "\"identifier\"", "\"identifier:\"", "\"%%\"", "\"|\"",
-  "\"%{...%}\"", "\";\"", "\"<tag>\"", "\"<*>\"", "\"<>\"", "\"integer\"",
-  "\"%param\"", "\"%union\"", "\"%empty\"", "$accept", "input",
+  static const char *const yy_sname[] =
+  {
+  "end of file", "error", "$undefined", "string", "%token", "%nterm",
+  "%type", "%destructor", "%printer", "%left", "%right", "%nonassoc",
+  "%precedence", "%prec", "%dprec", "%merge", "%code", "%default-prec",
+  "%define", "%defines", "%error-verbose", "%expect", "%expect-rr",
+  "%<flag>", "%file-prefix", "%glr-parser", "%initial-action", "%language",
+  "%name-prefix", "%no-default-prec", "%no-lines",
+  "%nondeterministic-parser", "%output", "%pure-parser", "%require",
+  "%skeleton", "%start", "%token-table", "%verbose", "%yacc", "{...}",
+  "%?{...}", "[identifier]", "character literal", ":", "epilogue", "=",
+  "identifier", "identifier:", "%%", "|", "%{...%}", ";", "<tag>", "<*>",
+  "<>", "integer", "%param", "%union", "%empty", "$accept", "input",
   "prologue_declarations", "prologue_declaration", "$@1", "params",
   "grammar_declaration", "code_props_type", "union_name",
   "symbol_declaration", "$@2", "$@3", "precedence_declarator", "tag.opt",
@@ -555,12 +556,8 @@ static const char *const yytname[] =
   "rules_or_grammar_declaration", "rules", "$@4", "rhses.1", "rhs",
   "named_ref.opt", "variable", "value", "id", "id_colon", "symbol",
   "string_as_id", "string_as_id.opt", "epilogue.opt", YY_NULLPTR
-};
-
-static const char *
-yysymbol_name (int yysymbol)
-{
-  return yytname[yysymbol];
+  };
+  return yy_sname[yysymbol];
 }
 #endif
 
@@ -1577,56 +1574,6 @@ yystpcpy (char *yydest, const char *yysrc)
 #  endif
 # endif
 
-# ifndef yytnamerr
-/* Copy to YYRES the contents of YYSTR after stripping away unnecessary
-   quotes and backslashes, so that it's suitable for yyerror.  The
-   heuristic is that double-quoting is unnecessary unless the string
-   contains an apostrophe, a comma, or backslash (other than
-   backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
-   null, do not copy; instead, return the length of what the result
-   would have been.  */
-static YYPTRDIFF_T
-yytnamerr (char *yyres, const char *yystr)
-{
-  if (*yystr == '"')
-    {
-      YYPTRDIFF_T yyn = 0;
-      char const *yyp = yystr;
-
-      for (;;)
-        switch (*++yyp)
-          {
-          case '\'':
-          case ',':
-            goto do_not_strip_quotes;
-
-          case '\\':
-            if (*++yyp != '\\')
-              goto do_not_strip_quotes;
-            else
-              goto append;
-
-          append:
-          default:
-            if (yyres)
-              yyres[yyn] = *yyp;
-            yyn++;
-            break;
-
-          case '"':
-            if (yyres)
-              yyres[yyn] = '\0';
-            return yyn;
-          }
-    do_not_strip_quotes: ;
-    }
-
-  if (yyres)
-    return yystpcpy (yyres, yystr) - yyres;
-  else
-    return yystrlen (yystr);
-}
-# endif
 
 
 /* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
@@ -1682,7 +1629,7 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
     for (yyi = 0; yyi < yycount; ++yyi)
       {
         YYPTRDIFF_T yysize1
-          = yysize + yytnamerr (YY_NULLPTR, yytname[yyarg[yyi]]);
+          = yysize + yystrlen (yysymbol_name (yyarg[yyi]));
         if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
           yysize = yysize1;
         else
@@ -1708,7 +1655,7 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
     while ((*yyp = *yyformat) != '\0')
       if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
         {
-          yyp += yytnamerr (yyp, yytname[yyarg[yyi++]]);
+          yyp = yystpcpy (yyp, yysymbol_name (yyarg[yyi++]));
           yyformat += 2;
         }
       else

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -522,6 +522,10 @@ static const yytype_int16 yyrline[] =
 #endif
 
 #if 1
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (int yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
@@ -553,9 +557,6 @@ static const char *const yytname[] =
   "string_as_id", "string_as_id.opt", "epilogue.opt", YY_NULLPTR
 };
 
-/* The user-facing name of the symbol whose (internal) number is
-   YYSYMBOL.  No bounds checking.  */
-static const char *yysymbol_name (int yysymbol) YY_ATTRIBUTE_UNUSED;
 static const char *
 yysymbol_name (int yysymbol)
 {

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -1121,7 +1121,7 @@ static void
 yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
 {
   YYFPRINTF (yyo, "%s %s (",
-             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
+             yytype < YYNTOKENS ? "token" : "nterm", yysymbol_name (yytype));
 
   YY_LOCATION_PRINT (yyo, *yylocationp);
   YYFPRINTF (yyo, ": ");

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -485,16 +485,16 @@ union yyalloc
 #define YYLAST   234
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  60
+#define YYNTOKENS  61
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  42
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  122
+#define YYNRULES  123
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  166
+#define YYNSTATES  167
 
 #define YYUNDEFTOK  2
-#define YYMAXUTOK   314
+#define YYMAXUTOK   315
 
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
@@ -505,19 +505,19 @@ union yyalloc
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   293,   293,   302,   303,   307,   308,   314,   318,   323,
-     324,   329,   330,   331,   332,   333,   338,   343,   344,   345,
-     346,   347,   348,   348,   349,   350,   351,   352,   353,   354,
-     355,   356,   360,   361,   370,   371,   375,   386,   390,   394,
-     402,   412,   413,   423,   424,   430,   443,   443,   448,   448,
-     453,   457,   467,   468,   469,   470,   474,   475,   480,   481,
-     485,   486,   490,   491,   492,   505,   514,   518,   522,   530,
-     531,   535,   548,   549,   561,   565,   569,   577,   579,   584,
-     591,   601,   605,   609,   617,   622,   634,   635,   641,   642,
-     643,   650,   650,   658,   659,   660,   665,   668,   670,   672,
-     674,   676,   678,   680,   682,   684,   689,   690,   699,   723,
-     724,   725,   726,   738,   740,   767,   772,   773,   778,   787,
-     788,   792,   793
+       0,   294,   294,   303,   304,   308,   309,   315,   319,   324,
+     325,   330,   331,   332,   333,   334,   339,   344,   345,   346,
+     347,   348,   349,   349,   350,   351,   352,   353,   354,   355,
+     356,   357,   361,   362,   371,   372,   376,   387,   391,   395,
+     403,   413,   414,   424,   425,   431,   444,   444,   449,   449,
+     454,   458,   468,   469,   470,   471,   475,   476,   481,   482,
+     486,   487,   491,   492,   493,   506,   515,   519,   523,   531,
+     532,   536,   549,   550,   555,   556,   557,   575,   579,   583,
+     591,   593,   598,   605,   615,   619,   623,   631,   636,   648,
+     649,   655,   656,   657,   664,   664,   672,   673,   674,   679,
+     682,   684,   686,   688,   690,   692,   694,   696,   698,   703,
+     704,   713,   737,   738,   739,   740,   752,   754,   781,   786,
+     787,   792,   800,   801
 };
 #endif
 
@@ -535,27 +535,27 @@ yysymbol_name (int yysymbol)
 {
   static const char *const yy_sname[] =
   {
-  "end of file", "error", "$undefined", "string", "%token", "%nterm",
-  "%type", "%destructor", "%printer", "%left", "%right", "%nonassoc",
-  "%precedence", "%prec", "%dprec", "%merge", "%code", "%default-prec",
-  "%define", "%defines", "%error-verbose", "%expect", "%expect-rr",
-  "%<flag>", "%file-prefix", "%glr-parser", "%initial-action", "%language",
-  "%name-prefix", "%no-default-prec", "%no-lines",
-  "%nondeterministic-parser", "%output", "%pure-parser", "%require",
-  "%skeleton", "%start", "%token-table", "%verbose", "%yacc", "{...}",
-  "%?{...}", "[identifier]", "character literal", ":", "epilogue", "=",
-  "identifier", "identifier:", "%%", "|", "%{...%}", ";", "<tag>", "<*>",
-  "<>", "integer", "%param", "%union", "%empty", "$accept", "input",
+  "end of file", "error", "$undefined", "string", "translatable string",
+  "%token", "%nterm", "%type", "%destructor", "%printer", "%left",
+  "%right", "%nonassoc", "%precedence", "%prec", "%dprec", "%merge",
+  "%code", "%default-prec", "%define", "%defines", "%error-verbose",
+  "%expect", "%expect-rr", "%<flag>", "%file-prefix", "%glr-parser",
+  "%initial-action", "%language", "%name-prefix", "%no-default-prec",
+  "%no-lines", "%nondeterministic-parser", "%output", "%pure-parser",
+  "%require", "%skeleton", "%start", "%token-table", "%verbose", "%yacc",
+  "{...}", "%?{...}", "[identifier]", "character literal", ":", "epilogue",
+  "=", "identifier", "identifier:", "%%", "|", "%{...%}", ";", "<tag>",
+  "<*>", "<>", "integer", "%param", "%union", "%empty", "$accept", "input",
   "prologue_declarations", "prologue_declaration", "$@1", "params",
   "grammar_declaration", "code_props_type", "union_name",
   "symbol_declaration", "$@2", "$@3", "precedence_declarator", "tag.opt",
   "generic_symlist", "generic_symlist_item", "tag", "nterm_decls",
-  "token_decls", "token_decl.1", "token_decl", "int.opt",
+  "token_decls", "token_decl.1", "token_decl", "int.opt", "alias",
   "token_decls_for_prec", "token_decl_for_prec.1", "token_decl_for_prec",
   "symbol_decls", "symbol_decl.1", "grammar",
   "rules_or_grammar_declaration", "rules", "$@4", "rhses.1", "rhs",
   "named_ref.opt", "variable", "value", "id", "id_colon", "symbol",
-  "string_as_id", "string_as_id.opt", "epilogue.opt", YY_NULLPTR
+  "string_as_id", "epilogue.opt", YY_NULLPTR
   };
   return yy_sname[yysymbol];
 }
@@ -571,16 +571,17 @@ static const yytype_int16 yytoknum[] =
      275,   276,   277,   278,   279,   280,   281,   282,   283,   284,
      285,   286,   287,   288,   289,   290,   291,   292,   293,   294,
      295,   296,   297,   298,   299,   300,   301,   302,   303,   304,
-     305,   306,   307,   308,   309,   310,   311,   312,   313,   314
+     305,   306,   307,   308,   309,   310,   311,   312,   313,   314,
+     315
 };
 # endif
 
-#define YYPACT_NINF (-130)
+#define YYPACT_NINF (-80)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF (-122)
+#define YYTABLE_NINF (-123)
 
 #define yytable_value_is_error(Yyn) \
   0
@@ -589,23 +590,23 @@ static const yytype_int16 yytoknum[] =
      STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-    -130,    36,   110,  -130,   -22,  -130,  -130,     2,  -130,  -130,
-    -130,  -130,  -130,  -130,   -19,  -130,    -9,    40,  -130,   -17,
-      -2,  -130,    57,  -130,    21,    66,    77,  -130,  -130,  -130,
-      78,  -130,    87,    92,    44,  -130,  -130,  -130,   165,  -130,
-    -130,  -130,    50,  -130,  -130,    58,  -130,    29,  -130,    15,
-      15,  -130,  -130,  -130,    44,    47,    44,  -130,  -130,  -130,
-    -130,    61,  -130,    30,  -130,  -130,  -130,  -130,  -130,  -130,
-    -130,  -130,  -130,  -130,  -130,    51,  -130,    53,     8,  -130,
-    -130,    64,    67,  -130,    68,    20,    44,    56,    44,  -130,
-      69,  -130,   -37,    59,   -37,  -130,    69,  -130,    59,    44,
-      44,  -130,  -130,  -130,  -130,  -130,  -130,  -130,  -130,    79,
-    -130,  -130,  -130,  -130,  -130,   111,  -130,  -130,  -130,  -130,
-      20,  -130,  -130,  -130,    44,    44,  -130,  -130,  -130,   -37,
-     -37,  -130,   147,    44,  -130,   108,  -130,  -130,    44,   -37,
-    -130,  -130,  -130,   -21,   175,  -130,  -130,    44,    97,   101,
-      99,   100,  -130,  -130,  -130,   117,    64,   175,  -130,  -130,
-    -130,  -130,  -130,    64,  -130,  -130
+     -80,     5,   120,   -80,   -17,   -80,   -80,    23,   -80,   -80,
+     -80,   -80,   -80,   -80,    -7,   -80,    10,    58,   -80,     6,
+      34,   -80,    82,   -80,    54,    95,   101,   -80,   -80,   -80,
+     103,   -80,   105,   107,    24,   -80,   -80,   -80,   175,   -80,
+     -80,   -80,    64,   -80,   -80,    75,   -80,    61,   -80,   -15,
+     -15,   -80,   -80,   -80,    24,    63,    24,   -80,   -80,   -80,
+     -80,    77,   -80,    46,   -80,   -80,   -80,   -80,   -80,   -80,
+     -80,   -80,   -80,   -80,   -80,    67,   -80,    69,     7,   -80,
+     -80,    80,    93,   -80,    94,    -1,    24,   108,    24,   -80,
+      79,   -80,   -38,   109,   -38,   -80,    79,   -80,   109,    24,
+      24,   -80,   -80,   -80,   -80,   -80,   -80,   -80,   -80,   115,
+     -80,   -80,   -80,   -80,   -80,   123,   -80,   -80,   -80,   -80,
+      -1,   -80,   -80,   -80,    24,    24,   -80,   -80,   -80,   -38,
+     -38,   -80,    28,    24,   -80,   121,   -80,   -80,    24,   -38,
+     -80,   -80,   -80,   -80,   -23,    59,   -80,   -80,    24,   110,
+     111,   112,   114,   -80,   -80,   -80,   127,    80,    59,   -80,
+     -80,   -80,   -80,   -80,    80,   -80,   -80
 };
 
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -618,38 +619,38 @@ static const yytype_int8 yydefact[] =
        0,     7,     0,    15,     0,     0,     0,    38,    19,    20,
        0,    24,     0,     0,     0,    27,    28,    29,     0,     6,
       31,    22,    43,     4,     5,     0,    34,     0,    30,     0,
-       0,   118,   114,   113,     0,    50,    81,   116,    84,   117,
-      39,     0,   108,   109,    10,    12,    13,    14,    16,    17,
-      18,    21,    25,    26,    35,     0,   115,     0,     0,    86,
-      88,   106,     0,    44,     0,     0,     0,    51,    74,    77,
-      72,    80,     0,    49,    66,    69,    72,    47,    65,    82,
-       0,    85,    40,   111,   112,   110,     8,    90,    89,     0,
-      87,     2,   107,    91,    33,    23,    45,    62,    63,    64,
-      36,    58,    61,    60,    75,     0,    78,    73,    79,    67,
-       0,    70,   119,    83,   122,     0,    32,    59,    76,    68,
-     120,    71,    96,    92,    93,    96,    95,     0,     0,     0,
-       0,     0,    99,    57,   100,     0,   106,    94,   101,   102,
-     103,   104,   105,   106,    97,    98
+       0,   121,   117,   116,     0,    50,    84,   119,    87,   120,
+      39,     0,   111,   112,    10,    12,    13,    14,    16,    17,
+      18,    21,    25,    26,    35,     0,   118,     0,     0,    89,
+      91,   109,     0,    44,     0,     0,     0,    51,    77,    80,
+      72,    83,     0,    49,    66,    69,    72,    47,    65,    85,
+       0,    88,    40,   114,   115,   113,     8,    93,    92,     0,
+      90,     2,   110,    94,    33,    23,    45,    62,    63,    64,
+      36,    58,    61,    60,    78,     0,    81,    73,    82,    67,
+       0,    70,    74,    86,   123,     0,    32,    59,    79,    68,
+      76,    71,    75,    99,    95,    96,    99,    98,     0,     0,
+       0,     0,     0,   102,    57,   103,     0,   109,    97,   104,
+     105,   106,   107,   108,   109,   100,   101
 };
 
   /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
-    -130,  -130,  -130,  -130,  -130,  -130,   156,  -130,  -130,  -130,
-    -130,  -130,  -130,  -130,  -130,    43,  -130,  -130,   114,   -66,
-     -35,    83,  -130,   -84,   -53,  -130,   -47,  -130,    82,  -130,
-    -130,  -130,    35,  -129,  -130,  -130,   -46,  -130,   -34,   -36,
-    -130,  -130
+     -80,   -80,   -80,   -80,   -80,   -80,   172,   -80,   -80,   -80,
+     -80,   -80,   -80,   -80,   -80,    55,   -80,   -80,   139,   -54,
+     -59,    81,   -80,   -80,   -65,   -79,   -80,   -31,   -80,   113,
+     -80,   -80,   -80,    44,   -67,   -80,   -80,   -46,   -80,   -34,
+     -36,   -80
 };
 
   /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int16 yydefgoto[] =
 {
       -1,     1,     2,    43,    82,   115,    77,    45,    84,    46,
-      50,    49,    47,   155,   120,   121,   122,    97,    93,    94,
-      95,   128,    87,    88,    89,    55,    56,    78,    79,    80,
-     135,   143,   144,   113,    63,   106,    57,    81,    58,    59,
-     141,   111
+      50,    49,    47,   156,   120,   121,   122,    97,    93,    94,
+      95,   128,   141,    87,    88,    89,    55,    56,    78,    79,
+      80,   135,   144,   145,   113,    63,   106,    57,    81,    58,
+      59,   111
 };
 
   /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -657,57 +658,57 @@ static const yytype_int16 yydefgoto[] =
      number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
-      74,    90,   124,    96,    96,    51,    52,    99,  -121,    75,
+      74,    90,    51,    96,    96,     3,    52,  -122,    75,   126,
       53,    91,     5,     6,     7,     8,     9,    10,    11,    12,
-      13,    60,   101,    51,    14,    15,   129,   164,    61,   145,
-      48,   146,    51,   103,   165,   126,     3,    27,    62,    65,
-      90,   138,    90,    64,    34,    52,    96,    51,    96,    53,
-      91,   123,    91,   133,    66,    54,    76,   109,    52,   131,
-      67,    68,    53,    52,   139,   101,    42,    53,    92,    69,
-     104,   126,    52,   117,   118,   119,    53,   105,    90,    90,
-      70,    71,    86,    96,    96,   126,   123,    52,    91,    91,
-      72,    53,    90,    96,   131,    73,   140,    83,    85,   101,
-     100,   102,    91,   107,   131,   108,   112,   114,   116,   125,
-     156,     4,   130,   158,     5,     6,     7,     8,     9,    10,
-      11,    12,    13,   156,   134,   127,    14,    15,    16,    17,
-      18,    19,    20,    21,    22,    23,    24,    25,    26,    27,
-      28,    29,    30,    31,    32,    33,    34,    35,    36,    37,
-      51,   136,   142,   159,   160,   161,   162,   163,    44,    38,
-     110,    39,    40,   137,    98,     0,    75,    41,    42,     5,
-       6,     7,     8,     9,    10,    11,    12,    13,    51,   132,
-     157,    14,    15,     0,     0,     0,     0,     0,   147,   148,
-     149,     0,     0,     0,    27,     0,   150,   151,     0,     0,
-       0,    34,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,    76,     0,   -56,   152,     0,    52,     0,
-       0,     0,    53,    42,     0,     0,     0,     0,   153,     0,
-       0,     0,     0,     0,   154
+      13,   124,   101,    99,    14,    15,    51,    51,   146,    52,
+     147,    51,   140,    53,    60,   131,    48,    27,   129,    92,
+      90,    61,    90,    52,    34,   126,    96,    53,    96,   103,
+      91,   123,    91,   117,   118,   119,    76,   109,    62,   126,
+     138,    64,    51,    65,    51,   101,    42,    52,    52,   133,
+     131,    53,    53,   148,   149,   150,   139,    54,    90,    90,
+     131,   151,   152,    96,    96,    67,   123,   104,    91,    91,
+     165,    66,    90,    96,   105,    68,   142,   166,    69,   101,
+     -56,   153,    91,    52,    70,    52,    71,    53,    72,    53,
+      73,   157,    83,   154,   159,    86,    85,   100,   102,   155,
+     107,     4,   108,   112,   157,     5,     6,     7,     8,     9,
+      10,    11,    12,    13,   114,   116,   127,    14,    15,    16,
+      17,    18,    19,    20,    21,    22,    23,    24,    25,    26,
+      27,    28,    29,    30,    31,    32,    33,    34,    35,    36,
+      37,   134,   125,   130,   136,   161,   143,   160,   164,   162,
+      38,   163,    39,    40,    44,   137,    75,   132,    41,    42,
+       5,     6,     7,     8,     9,    10,    11,    12,    13,    98,
+     158,   110,    14,    15,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,    27,     0,     0,     0,     0,
+       0,     0,    34,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,    76,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,    42
 };
 
 static const yytype_int16 yycheck[] =
 {
-      34,    47,    86,    49,    50,     3,    43,    54,     0,     1,
-      47,    47,     4,     5,     6,     7,     8,     9,    10,    11,
-      12,    40,    56,     3,    16,    17,    92,   156,    47,    50,
-      52,    52,     3,     3,   163,    88,     0,    29,    47,    56,
-      86,   125,    88,     3,    36,    43,    92,     3,    94,    47,
-      86,    85,    88,   100,    56,    53,    48,    49,    43,    94,
-       3,    40,    47,    43,   130,    99,    58,    47,    53,     3,
-      40,   124,    43,    53,    54,    55,    47,    47,   124,   125,
-       3,     3,    53,   129,   130,   138,   120,    43,   124,   125,
-       3,    47,   138,   139,   129,     3,   132,    47,    40,   133,
-      53,    40,   138,    52,   139,    52,    42,    40,    40,    53,
-     144,     1,    53,   147,     4,     5,     6,     7,     8,     9,
-      10,    11,    12,   157,    45,    56,    16,    17,    18,    19,
+      34,    47,     3,    49,    50,     0,    44,     0,     1,    88,
+      48,    47,     5,     6,     7,     8,     9,    10,    11,    12,
+      13,    86,    56,    54,    17,    18,     3,     3,    51,    44,
+      53,     3,     4,    48,    41,    94,    53,    30,    92,    54,
+      86,    48,    88,    44,    37,   124,    92,    48,    94,     3,
+      86,    85,    88,    54,    55,    56,    49,    50,    48,   138,
+     125,     3,     3,    57,     3,    99,    59,    44,    44,   100,
+     129,    48,    48,    14,    15,    16,   130,    54,   124,   125,
+     139,    22,    23,   129,   130,     3,   120,    41,   124,   125,
+     157,    57,   138,   139,    48,    41,   132,   164,     3,   133,
+      41,    42,   138,    44,     3,    44,     3,    48,     3,    48,
+       3,   145,    48,    54,   148,    54,    41,    54,    41,    60,
+      53,     1,    53,    43,   158,     5,     6,     7,     8,     9,
+      10,    11,    12,    13,    41,    41,    57,    17,    18,    19,
       20,    21,    22,    23,    24,    25,    26,    27,    28,    29,
       30,    31,    32,    33,    34,    35,    36,    37,    38,    39,
-       3,    40,    44,    56,    53,    56,    56,    40,     2,    49,
-      78,    51,    52,   120,    50,    -1,     1,    57,    58,     4,
-       5,     6,     7,     8,     9,    10,    11,    12,     3,    96,
-     145,    16,    17,    -1,    -1,    -1,    -1,    -1,    13,    14,
-      15,    -1,    -1,    -1,    29,    -1,    21,    22,    -1,    -1,
-      -1,    36,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    48,    -1,    40,    41,    -1,    43,    -1,
-      -1,    -1,    47,    58,    -1,    -1,    -1,    -1,    53,    -1,
+      40,    46,    54,    54,    41,    54,    45,    57,    41,    57,
+      50,    57,    52,    53,     2,   120,     1,    96,    58,    59,
+       5,     6,     7,     8,     9,    10,    11,    12,    13,    50,
+     146,    78,    17,    18,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    30,    -1,    -1,    -1,    -1,
+      -1,    -1,    37,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    49,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    59
 };
 
@@ -715,41 +716,41 @@ static const yytype_int16 yycheck[] =
      symbol of state STATE-NUM.  */
 static const yytype_int8 yystos[] =
 {
-       0,    61,    62,     0,     1,     4,     5,     6,     7,     8,
-       9,    10,    11,    12,    16,    17,    18,    19,    20,    21,
-      22,    23,    24,    25,    26,    27,    28,    29,    30,    31,
-      32,    33,    34,    35,    36,    37,    38,    39,    49,    51,
-      52,    57,    58,    63,    66,    67,    69,    72,    52,    71,
-      70,     3,    43,    47,    53,    85,    86,    96,    98,    99,
-      40,    47,    47,    94,     3,    56,    56,     3,    40,     3,
-       3,     3,     3,     3,    98,     1,    48,    66,    87,    88,
-      89,    97,    64,    47,    68,    40,    53,    82,    83,    84,
-      96,    99,    53,    78,    79,    80,    96,    77,    78,    86,
-      53,    98,    40,     3,    40,    47,    95,    52,    52,    49,
-      88,   101,    42,    93,    40,    65,    40,    53,    54,    55,
-      74,    75,    76,    98,    83,    53,    84,    56,    81,    79,
-      53,    80,    81,    86,    45,    90,    40,    75,    83,    79,
-      99,   100,    44,    91,    92,    50,    52,    13,    14,    15,
-      21,    22,    41,    53,    59,    73,    98,    92,    98,    56,
-      53,    56,    56,    40,    93,    93
+       0,    62,    63,     0,     1,     5,     6,     7,     8,     9,
+      10,    11,    12,    13,    17,    18,    19,    20,    21,    22,
+      23,    24,    25,    26,    27,    28,    29,    30,    31,    32,
+      33,    34,    35,    36,    37,    38,    39,    40,    50,    52,
+      53,    58,    59,    64,    67,    68,    70,    73,    53,    72,
+      71,     3,    44,    48,    54,    87,    88,    98,   100,   101,
+      41,    48,    48,    96,     3,    57,    57,     3,    41,     3,
+       3,     3,     3,     3,   100,     1,    49,    67,    89,    90,
+      91,    99,    65,    48,    69,    41,    54,    84,    85,    86,
+      98,   101,    54,    79,    80,    81,    98,    78,    79,    88,
+      54,   100,    41,     3,    41,    48,    97,    53,    53,    50,
+      90,   102,    43,    95,    41,    66,    41,    54,    55,    56,
+      75,    76,    77,   100,    85,    54,    86,    57,    82,    80,
+      54,    81,    82,    88,    46,    92,    41,    76,    85,    80,
+       4,    83,   101,    45,    93,    94,    51,    53,    14,    15,
+      16,    22,    23,    42,    54,    60,    74,   100,    94,   100,
+      57,    54,    57,    57,    41,    95,    95
 };
 
   /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
 static const yytype_int8 yyr1[] =
 {
-       0,    60,    61,    62,    62,    63,    63,    63,    63,    63,
-      63,    63,    63,    63,    63,    63,    63,    63,    63,    63,
-      63,    63,    64,    63,    63,    63,    63,    63,    63,    63,
-      63,    63,    65,    65,    66,    66,    66,    66,    66,    66,
-      66,    67,    67,    68,    68,    66,    70,    69,    71,    69,
-      69,    69,    72,    72,    72,    72,    73,    73,    74,    74,
-      75,    75,    76,    76,    76,    77,    78,    78,    78,    79,
-      79,    80,    81,    81,    82,    82,    82,    83,    83,    84,
-      84,    85,    85,    85,    86,    86,    87,    87,    88,    88,
-      88,    90,    89,    91,    91,    91,    92,    92,    92,    92,
-      92,    92,    92,    92,    92,    92,    93,    93,    94,    95,
-      95,    95,    95,    96,    96,    97,    98,    98,    99,   100,
-     100,   101,   101
+       0,    61,    62,    63,    63,    64,    64,    64,    64,    64,
+      64,    64,    64,    64,    64,    64,    64,    64,    64,    64,
+      64,    64,    65,    64,    64,    64,    64,    64,    64,    64,
+      64,    64,    66,    66,    67,    67,    67,    67,    67,    67,
+      67,    68,    68,    69,    69,    67,    71,    70,    72,    70,
+      70,    70,    73,    73,    73,    73,    74,    74,    75,    75,
+      76,    76,    77,    77,    77,    78,    79,    79,    79,    80,
+      80,    81,    82,    82,    83,    83,    83,    84,    84,    84,
+      85,    85,    86,    86,    87,    87,    87,    88,    88,    89,
+      89,    90,    90,    90,    92,    91,    93,    93,    93,    94,
+      94,    94,    94,    94,    94,    94,    94,    94,    94,    95,
+      95,    96,    97,    97,    97,    97,    98,    98,    99,   100,
+     100,   101,   102,   102
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
@@ -762,12 +763,12 @@ static const yytype_int8 yyr2[] =
        3,     1,     1,     0,     1,     3,     0,     3,     0,     3,
        2,     2,     1,     1,     1,     1,     0,     1,     1,     2,
        1,     1,     1,     1,     1,     1,     1,     2,     3,     1,
-       2,     3,     0,     1,     1,     2,     3,     1,     2,     2,
-       1,     1,     2,     3,     1,     2,     1,     2,     1,     2,
-       2,     0,     5,     1,     3,     2,     0,     3,     4,     2,
-       2,     3,     3,     3,     3,     3,     0,     1,     1,     0,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     0,
-       1,     0,     2
+       2,     3,     0,     1,     0,     1,     1,     1,     2,     3,
+       1,     2,     2,     1,     1,     2,     3,     1,     2,     1,
+       2,     1,     2,     2,     0,     5,     1,     3,     2,     0,
+       3,     4,     2,     2,     3,     3,     3,     3,     3,     0,
+       1,     1,     0,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     0,     2
 };
 
 
@@ -931,67 +932,71 @@ tron (yyo);
          { fputs (((*yyvaluep).STRING), yyo); }
         break;
 
-    case 20: /* "%error-verbose"  */
+    case 4: /* "translatable string"  */
+         { fputs (((*yyvaluep).TSTRING), yyo); }
+        break;
+
+    case 21: /* "%error-verbose"  */
          { fputs (((*yyvaluep).PERCENT_ERROR_VERBOSE), yyo); }
         break;
 
-    case 23: /* "%<flag>"  */
+    case 24: /* "%<flag>"  */
          { fprintf (yyo, "%%%s", ((*yyvaluep).PERCENT_FLAG)); }
         break;
 
-    case 24: /* "%file-prefix"  */
+    case 25: /* "%file-prefix"  */
          { fputs (((*yyvaluep).PERCENT_FILE_PREFIX), yyo); }
         break;
 
-    case 28: /* "%name-prefix"  */
+    case 29: /* "%name-prefix"  */
          { fputs (((*yyvaluep).PERCENT_NAME_PREFIX), yyo); }
         break;
 
-    case 33: /* "%pure-parser"  */
+    case 34: /* "%pure-parser"  */
          { fputs (((*yyvaluep).PERCENT_PURE_PARSER), yyo); }
         break;
 
-    case 40: /* "{...}"  */
+    case 41: /* "{...}"  */
          { fputs (((*yyvaluep).BRACED_CODE), yyo); }
         break;
 
-    case 41: /* "%?{...}"  */
+    case 42: /* "%?{...}"  */
          { fputs (((*yyvaluep).BRACED_PREDICATE), yyo); }
         break;
 
-    case 42: /* "[identifier]"  */
+    case 43: /* "[identifier]"  */
          { fprintf (yyo, "[%s]", ((*yyvaluep).BRACKETED_ID)); }
         break;
 
-    case 43: /* "character literal"  */
+    case 44: /* "character literal"  */
          { fputs (char_name (((*yyvaluep).CHAR)), yyo); }
         break;
 
-    case 45: /* "epilogue"  */
+    case 46: /* "epilogue"  */
          { fputs (((*yyvaluep).EPILOGUE), yyo); }
         break;
 
-    case 47: /* "identifier"  */
+    case 48: /* "identifier"  */
          { fputs (((*yyvaluep).ID), yyo); }
         break;
 
-    case 48: /* "identifier:"  */
+    case 49: /* "identifier:"  */
          { fprintf (yyo, "%s:", ((*yyvaluep).ID_COLON)); }
         break;
 
-    case 51: /* "%{...%}"  */
+    case 52: /* "%{...%}"  */
          { fputs (((*yyvaluep).PROLOGUE), yyo); }
         break;
 
-    case 53: /* "<tag>"  */
+    case 54: /* "<tag>"  */
          { fprintf (yyo, "<%s>", ((*yyvaluep).TAG)); }
         break;
 
-    case 56: /* "integer"  */
+    case 57: /* "integer"  */
          { fprintf (yyo, "%d", ((*yyvaluep).INT)); }
         break;
 
-    case 57: /* "%param"  */
+    case 58: /* "%param"  */
 {
   switch (((*yyvaluep).PERCENT_PARAM))
     {
@@ -1006,71 +1011,75 @@ tron (yyo);
 }
         break;
 
-    case 67: /* code_props_type  */
+    case 68: /* code_props_type  */
          { fprintf (yyo, "%s", code_props_type_string (((*yyvaluep).code_props_type))); }
         break;
 
-    case 73: /* tag.opt  */
-         { fputs (((*yyvaluep).yytype_73), yyo); }
+    case 74: /* tag.opt  */
+         { fputs (((*yyvaluep).yytype_74), yyo); }
         break;
 
-    case 74: /* generic_symlist  */
+    case 75: /* generic_symlist  */
          { symbol_list_syms_print (((*yyvaluep).generic_symlist), yyo); }
         break;
 
-    case 75: /* generic_symlist_item  */
+    case 76: /* generic_symlist_item  */
          { symbol_list_syms_print (((*yyvaluep).generic_symlist_item), yyo); }
         break;
 
-    case 76: /* tag  */
+    case 77: /* tag  */
          { fprintf (yyo, "<%s>", ((*yyvaluep).tag)); }
         break;
 
-    case 77: /* nterm_decls  */
+    case 78: /* nterm_decls  */
          { symbol_list_syms_print (((*yyvaluep).nterm_decls), yyo); }
         break;
 
-    case 78: /* token_decls  */
+    case 79: /* token_decls  */
          { symbol_list_syms_print (((*yyvaluep).token_decls), yyo); }
         break;
 
-    case 79: /* token_decl.1  */
-         { symbol_list_syms_print (((*yyvaluep).yytype_79), yyo); }
+    case 80: /* token_decl.1  */
+         { symbol_list_syms_print (((*yyvaluep).yytype_80), yyo); }
         break;
 
-    case 80: /* token_decl  */
+    case 81: /* token_decl  */
          { fprintf (yyo, "%s", ((*yyvaluep).token_decl) ? ((*yyvaluep).token_decl)->tag : "<NULL>"); }
         break;
 
-    case 81: /* int.opt  */
-         { fprintf (yyo, "%d", ((*yyvaluep).yytype_81)); }
+    case 82: /* int.opt  */
+         { fprintf (yyo, "%d", ((*yyvaluep).yytype_82)); }
         break;
 
-    case 82: /* token_decls_for_prec  */
+    case 83: /* alias  */
+         { fprintf (yyo, "%s", ((*yyvaluep).alias) ? ((*yyvaluep).alias)->tag : "<NULL>"); }
+        break;
+
+    case 84: /* token_decls_for_prec  */
          { symbol_list_syms_print (((*yyvaluep).token_decls_for_prec), yyo); }
         break;
 
-    case 83: /* token_decl_for_prec.1  */
-         { symbol_list_syms_print (((*yyvaluep).yytype_83), yyo); }
+    case 85: /* token_decl_for_prec.1  */
+         { symbol_list_syms_print (((*yyvaluep).yytype_85), yyo); }
         break;
 
-    case 84: /* token_decl_for_prec  */
+    case 86: /* token_decl_for_prec  */
          { fprintf (yyo, "%s", ((*yyvaluep).token_decl_for_prec) ? ((*yyvaluep).token_decl_for_prec)->tag : "<NULL>"); }
         break;
 
-    case 85: /* symbol_decls  */
+    case 87: /* symbol_decls  */
          { symbol_list_syms_print (((*yyvaluep).symbol_decls), yyo); }
         break;
 
-    case 86: /* symbol_decl.1  */
-         { symbol_list_syms_print (((*yyvaluep).yytype_86), yyo); }
+    case 88: /* symbol_decl.1  */
+         { symbol_list_syms_print (((*yyvaluep).yytype_88), yyo); }
         break;
 
-    case 94: /* variable  */
+    case 96: /* variable  */
          { fputs (((*yyvaluep).variable), yyo); }
         break;
 
-    case 95: /* value  */
+    case 97: /* value  */
 {
   switch (((*yyvaluep).value).kind)
     {
@@ -1081,24 +1090,20 @@ tron (yyo);
 }
         break;
 
-    case 96: /* id  */
+    case 98: /* id  */
          { fprintf (yyo, "%s", ((*yyvaluep).id) ? ((*yyvaluep).id)->tag : "<NULL>"); }
         break;
 
-    case 97: /* id_colon  */
+    case 99: /* id_colon  */
          { fprintf (yyo, "%s:", ((*yyvaluep).id_colon)->tag); }
         break;
 
-    case 98: /* symbol  */
+    case 100: /* symbol  */
          { fprintf (yyo, "%s", ((*yyvaluep).symbol) ? ((*yyvaluep).symbol)->tag : "<NULL>"); }
         break;
 
-    case 99: /* string_as_id  */
+    case 101: /* string_as_id  */
          { fprintf (yyo, "%s", ((*yyvaluep).string_as_id) ? ((*yyvaluep).string_as_id)->tag : "<NULL>"); }
-        break;
-
-    case 100: /* string_as_id.opt  */
-         { fprintf (yyo, "%s", ((*yyvaluep).yytype_100) ? ((*yyvaluep).yytype_100)->tag : "<NULL>"); }
         break;
 
       default:
@@ -1684,40 +1689,40 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   switch (yytype)
     {
-    case 74: /* generic_symlist  */
+    case 75: /* generic_symlist  */
             { symbol_list_free (((*yyvaluep).generic_symlist)); }
         break;
 
-    case 75: /* generic_symlist_item  */
+    case 76: /* generic_symlist_item  */
             { symbol_list_free (((*yyvaluep).generic_symlist_item)); }
         break;
 
-    case 77: /* nterm_decls  */
+    case 78: /* nterm_decls  */
             { symbol_list_free (((*yyvaluep).nterm_decls)); }
         break;
 
-    case 78: /* token_decls  */
+    case 79: /* token_decls  */
             { symbol_list_free (((*yyvaluep).token_decls)); }
         break;
 
-    case 79: /* token_decl.1  */
-            { symbol_list_free (((*yyvaluep).yytype_79)); }
+    case 80: /* token_decl.1  */
+            { symbol_list_free (((*yyvaluep).yytype_80)); }
         break;
 
-    case 82: /* token_decls_for_prec  */
+    case 84: /* token_decls_for_prec  */
             { symbol_list_free (((*yyvaluep).token_decls_for_prec)); }
         break;
 
-    case 83: /* token_decl_for_prec.1  */
-            { symbol_list_free (((*yyvaluep).yytype_83)); }
+    case 85: /* token_decl_for_prec.1  */
+            { symbol_list_free (((*yyvaluep).yytype_85)); }
         break;
 
-    case 85: /* symbol_decls  */
+    case 87: /* symbol_decls  */
             { symbol_list_free (((*yyvaluep).symbol_decls)); }
         break;
 
-    case 86: /* symbol_decl.1  */
-            { symbol_list_free (((*yyvaluep).yytype_86)); }
+    case 88: /* symbol_decl.1  */
+            { symbol_list_free (((*yyvaluep).yytype_88)); }
         break;
 
       default:
@@ -2297,11 +2302,11 @@ yyreduce:
     break;
 
   case 56:
-         { (yyval.yytype_73) = NULL; }
+         { (yyval.yytype_74) = NULL; }
     break;
 
   case 57:
-         { (yyval.yytype_73) = (yyvsp[0].TAG); }
+         { (yyval.yytype_74) = (yyvsp[0].TAG); }
     break;
 
   case 59:
@@ -2326,207 +2331,223 @@ yyreduce:
 
   case 66:
     {
-      (yyval.token_decls) = (yyvsp[0].yytype_79);
+      (yyval.token_decls) = (yyvsp[0].yytype_80);
     }
     break;
 
   case 67:
     {
-      (yyval.token_decls) = symbol_list_type_set ((yyvsp[0].yytype_79), (yyvsp[-1].TAG), (yylsp[-1]));
+      (yyval.token_decls) = symbol_list_type_set ((yyvsp[0].yytype_80), (yyvsp[-1].TAG), (yylsp[-1]));
     }
     break;
 
   case 68:
     {
-      (yyval.token_decls) = symbol_list_append ((yyvsp[-2].token_decls), symbol_list_type_set ((yyvsp[0].yytype_79), (yyvsp[-1].TAG), (yylsp[-1])));
+      (yyval.token_decls) = symbol_list_append ((yyvsp[-2].token_decls), symbol_list_type_set ((yyvsp[0].yytype_80), (yyvsp[-1].TAG), (yylsp[-1])));
     }
     break;
 
   case 69:
-                            { (yyval.yytype_79) = symbol_list_sym_new ((yyvsp[0].token_decl), (yylsp[0])); }
+                            { (yyval.yytype_80) = symbol_list_sym_new ((yyvsp[0].token_decl), (yylsp[0])); }
     break;
 
   case 70:
-                            { (yyval.yytype_79) = symbol_list_append ((yyvsp[-1].yytype_79), symbol_list_sym_new ((yyvsp[0].token_decl), (yylsp[0]))); }
+                            { (yyval.yytype_80) = symbol_list_append ((yyvsp[-1].yytype_80), symbol_list_sym_new ((yyvsp[0].token_decl), (yylsp[0]))); }
     break;
 
   case 71:
     {
       (yyval.token_decl) = (yyvsp[-2].id);
       symbol_class_set ((yyvsp[-2].id), current_class, (yylsp[-2]), true);
-      if (0 <= (yyvsp[-1].yytype_81))
-        symbol_user_token_number_set ((yyvsp[-2].id), (yyvsp[-1].yytype_81), (yylsp[-1]));
-      if ((yyvsp[0].yytype_100))
-        symbol_make_alias ((yyvsp[-2].id), (yyvsp[0].yytype_100), (yylsp[0]));
+      if (0 <= (yyvsp[-1].yytype_82))
+        symbol_user_token_number_set ((yyvsp[-2].id), (yyvsp[-1].yytype_82), (yylsp[-1]));
+      if ((yyvsp[0].alias))
+        symbol_make_alias ((yyvsp[-2].id), (yyvsp[0].alias), (yylsp[0]));
     }
     break;
 
   case 72:
-          { (yyval.yytype_81) = -1; }
+          { (yyval.yytype_82) = -1; }
     break;
 
   case 74:
-    {
-      (yyval.token_decls_for_prec) = (yyvsp[0].yytype_83);
-    }
+                 { (yyval.alias) = NULL; }
     break;
 
   case 75:
-    {
-      (yyval.token_decls_for_prec) = symbol_list_type_set ((yyvsp[0].yytype_83), (yyvsp[-1].TAG), (yylsp[-1]));
-    }
+                 { (yyval.alias) = (yyvsp[0].string_as_id); }
     break;
 
   case 76:
     {
-      (yyval.token_decls_for_prec) = symbol_list_append ((yyvsp[-2].token_decls_for_prec), symbol_list_type_set ((yyvsp[0].yytype_83), (yyvsp[-1].TAG), (yylsp[-1])));
+      (yyval.alias) = symbol_get (quotearg_style (c_quoting_style, (yyvsp[0].TSTRING)), (yylsp[0]));
+      symbol_class_set ((yyval.alias), token_sym, (yylsp[0]), false);
+      (yyval.alias)->translatable = true;
     }
     break;
 
   case 77:
-    { (yyval.yytype_83) = symbol_list_sym_new ((yyvsp[0].token_decl_for_prec), (yylsp[0])); }
+    {
+      (yyval.token_decls_for_prec) = (yyvsp[0].yytype_85);
+    }
     break;
 
   case 78:
-    { (yyval.yytype_83) = symbol_list_append ((yyvsp[-1].yytype_83), symbol_list_sym_new ((yyvsp[0].token_decl_for_prec), (yylsp[0]))); }
+    {
+      (yyval.token_decls_for_prec) = symbol_list_type_set ((yyvsp[0].yytype_85), (yyvsp[-1].TAG), (yylsp[-1]));
+    }
     break;
 
   case 79:
     {
-      (yyval.token_decl_for_prec) = (yyvsp[-1].id);
-      symbol_class_set ((yyvsp[-1].id), token_sym, (yylsp[-1]), false);
-      if (0 <= (yyvsp[0].yytype_81))
-        symbol_user_token_number_set ((yyvsp[-1].id), (yyvsp[0].yytype_81), (yylsp[0]));
+      (yyval.token_decls_for_prec) = symbol_list_append ((yyvsp[-2].token_decls_for_prec), symbol_list_type_set ((yyvsp[0].yytype_85), (yyvsp[-1].TAG), (yylsp[-1])));
     }
     break;
 
+  case 80:
+    { (yyval.yytype_85) = symbol_list_sym_new ((yyvsp[0].token_decl_for_prec), (yylsp[0])); }
+    break;
+
   case 81:
-    {
-      (yyval.symbol_decls) = (yyvsp[0].yytype_86);
-    }
+    { (yyval.yytype_85) = symbol_list_append ((yyvsp[-1].yytype_85), symbol_list_sym_new ((yyvsp[0].token_decl_for_prec), (yylsp[0]))); }
     break;
 
   case 82:
     {
-      (yyval.symbol_decls) = symbol_list_type_set ((yyvsp[0].yytype_86), (yyvsp[-1].TAG), (yylsp[-1]));
-    }
-    break;
-
-  case 83:
-    {
-      (yyval.symbol_decls) = symbol_list_append ((yyvsp[-2].symbol_decls), symbol_list_type_set ((yyvsp[0].yytype_86), (yyvsp[-1].TAG), (yylsp[-1])));
+      (yyval.token_decl_for_prec) = (yyvsp[-1].id);
+      symbol_class_set ((yyvsp[-1].id), token_sym, (yylsp[-1]), false);
+      if (0 <= (yyvsp[0].yytype_82))
+        symbol_user_token_number_set ((yyvsp[-1].id), (yyvsp[0].yytype_82), (yylsp[0]));
     }
     break;
 
   case 84:
     {
-      symbol_class_set ((yyvsp[0].symbol), pct_type_sym, (yylsp[0]), false);
-      (yyval.yytype_86) = symbol_list_sym_new ((yyvsp[0].symbol), (yylsp[0]));
+      (yyval.symbol_decls) = (yyvsp[0].yytype_88);
     }
     break;
 
   case 85:
     {
-      symbol_class_set ((yyvsp[0].symbol), pct_type_sym, (yylsp[0]), false);
-      (yyval.yytype_86) = symbol_list_append ((yyvsp[-1].yytype_86), symbol_list_sym_new ((yyvsp[0].symbol), (yylsp[0])));
+      (yyval.symbol_decls) = symbol_list_type_set ((yyvsp[0].yytype_88), (yyvsp[-1].TAG), (yylsp[-1]));
     }
     break;
 
-  case 90:
+  case 86:
+    {
+      (yyval.symbol_decls) = symbol_list_append ((yyvsp[-2].symbol_decls), symbol_list_type_set ((yyvsp[0].yytype_88), (yyvsp[-1].TAG), (yylsp[-1])));
+    }
+    break;
+
+  case 87:
+    {
+      symbol_class_set ((yyvsp[0].symbol), pct_type_sym, (yylsp[0]), false);
+      (yyval.yytype_88) = symbol_list_sym_new ((yyvsp[0].symbol), (yylsp[0]));
+    }
+    break;
+
+  case 88:
+    {
+      symbol_class_set ((yyvsp[0].symbol), pct_type_sym, (yylsp[0]), false);
+      (yyval.yytype_88) = symbol_list_append ((yyvsp[-1].yytype_88), symbol_list_sym_new ((yyvsp[0].symbol), (yylsp[0])));
+    }
+    break;
+
+  case 93:
     {
       yyerrok;
     }
     break;
 
-  case 91:
-                         { current_lhs ((yyvsp[-1].id_colon), (yylsp[-1]), (yyvsp[0].yytype_93)); }
+  case 94:
+                         { current_lhs ((yyvsp[-1].id_colon), (yylsp[-1]), (yyvsp[0].yytype_95)); }
     break;
 
-  case 92:
+  case 95:
     {
       /* Free the current lhs. */
       current_lhs (0, (yylsp[-4]), 0);
     }
     break;
 
-  case 93:
-                     { grammar_current_rule_end ((yylsp[0])); }
-    break;
-
-  case 94:
-                     { grammar_current_rule_end ((yylsp[0])); }
-    break;
-
   case 96:
+                     { grammar_current_rule_end ((yylsp[0])); }
+    break;
+
+  case 97:
+                     { grammar_current_rule_end ((yylsp[0])); }
+    break;
+
+  case 99:
     { grammar_current_rule_begin (current_lhs_symbol, current_lhs_loc,
                                   current_lhs_named_ref); }
     break;
 
-  case 97:
-    { grammar_current_rule_symbol_append ((yyvsp[-1].symbol), (yylsp[-1]), (yyvsp[0].yytype_93)); }
-    break;
-
-  case 98:
-    { grammar_current_rule_action_append ((yyvsp[-1].BRACED_CODE), (yylsp[-1]), (yyvsp[0].yytype_93), (yyvsp[-2].yytype_73)); }
-    break;
-
-  case 99:
-    { grammar_current_rule_predicate_append ((yyvsp[0].BRACED_PREDICATE), (yylsp[0])); }
-    break;
-
   case 100:
-    { grammar_current_rule_empty_set ((yylsp[0])); }
+    { grammar_current_rule_symbol_append ((yyvsp[-1].symbol), (yylsp[-1]), (yyvsp[0].yytype_95)); }
     break;
 
   case 101:
-    { grammar_current_rule_prec_set ((yyvsp[0].symbol), (yylsp[0])); }
+    { grammar_current_rule_action_append ((yyvsp[-1].BRACED_CODE), (yylsp[-1]), (yyvsp[0].yytype_95), (yyvsp[-2].yytype_74)); }
     break;
 
   case 102:
-    { grammar_current_rule_dprec_set ((yyvsp[0].INT), (yylsp[0])); }
+    { grammar_current_rule_predicate_append ((yyvsp[0].BRACED_PREDICATE), (yylsp[0])); }
     break;
 
   case 103:
-    { grammar_current_rule_merge_set ((yyvsp[0].TAG), (yylsp[0])); }
+    { grammar_current_rule_empty_set ((yylsp[0])); }
     break;
 
   case 104:
-    { grammar_current_rule_expect_sr ((yyvsp[0].INT), (yylsp[0])); }
+    { grammar_current_rule_prec_set ((yyvsp[0].symbol), (yylsp[0])); }
     break;
 
   case 105:
-    { grammar_current_rule_expect_rr ((yyvsp[0].INT), (yylsp[0])); }
+    { grammar_current_rule_dprec_set ((yyvsp[0].INT), (yylsp[0])); }
     break;
 
   case 106:
-                 { (yyval.yytype_93) = NULL; }
+    { grammar_current_rule_merge_set ((yyvsp[0].TAG), (yylsp[0])); }
     break;
 
   case 107:
-                 { (yyval.yytype_93) = named_ref_new ((yyvsp[0].BRACKETED_ID), (yylsp[0])); }
+    { grammar_current_rule_expect_sr ((yyvsp[0].INT), (yylsp[0])); }
+    break;
+
+  case 108:
+    { grammar_current_rule_expect_rr ((yyvsp[0].INT), (yylsp[0])); }
     break;
 
   case 109:
-          { (yyval.value).kind = muscle_keyword; (yyval.value).chars = ""; }
+                 { (yyval.yytype_95) = NULL; }
     break;
 
   case 110:
-          { (yyval.value).kind = muscle_keyword; (yyval.value).chars = (yyvsp[0].ID); }
-    break;
-
-  case 111:
-          { (yyval.value).kind = muscle_string;  (yyval.value).chars = (yyvsp[0].STRING); }
+                 { (yyval.yytype_95) = named_ref_new ((yyvsp[0].BRACKETED_ID), (yylsp[0])); }
     break;
 
   case 112:
-          { (yyval.value).kind = muscle_code;    (yyval.value).chars = strip_braces ((yyvsp[0].BRACED_CODE)); }
+          { (yyval.value).kind = muscle_keyword; (yyval.value).chars = ""; }
     break;
 
   case 113:
-    { (yyval.id) = symbol_from_uniqstr ((yyvsp[0].ID), (yylsp[0])); }
+          { (yyval.value).kind = muscle_keyword; (yyval.value).chars = (yyvsp[0].ID); }
     break;
 
   case 114:
+          { (yyval.value).kind = muscle_string;  (yyval.value).chars = (yyvsp[0].STRING); }
+    break;
+
+  case 115:
+          { (yyval.value).kind = muscle_code;    (yyval.value).chars = strip_braces ((yyvsp[0].BRACED_CODE)); }
+    break;
+
+  case 116:
+    { (yyval.id) = symbol_from_uniqstr ((yyvsp[0].ID), (yylsp[0])); }
+    break;
+
+  case 117:
     {
       const char *var = "api.token.raw";
       if (current_class == nterm_sym)
@@ -2552,22 +2573,18 @@ yyreduce:
     }
     break;
 
-  case 115:
+  case 118:
            { (yyval.id_colon) = symbol_from_uniqstr ((yyvsp[0].ID_COLON), (yylsp[0])); }
     break;
 
-  case 118:
+  case 121:
     {
       (yyval.string_as_id) = symbol_get (quotearg_style (c_quoting_style, (yyvsp[0].STRING)), (yylsp[0]));
       symbol_class_set ((yyval.string_as_id), token_sym, (yylsp[0]), false);
     }
     break;
 
-  case 119:
-                     { (yyval.yytype_100) = NULL; }
-    break;
-
-  case 122:
+  case 123:
     {
       muscle_code_grow ("epilogue", translate_code ((yyvsp[0].EPILOGUE), (yylsp[0]), true), (yylsp[0]));
       code_scanner_last_string_free ();

--- a/src/parse-gram.h
+++ b/src/parse-gram.h
@@ -79,62 +79,63 @@ extern int gram_debug;
   {
     GRAM_EOF = 0,
     STRING = 3,
-    PERCENT_TOKEN = 4,
-    PERCENT_NTERM = 5,
-    PERCENT_TYPE = 6,
-    PERCENT_DESTRUCTOR = 7,
-    PERCENT_PRINTER = 8,
-    PERCENT_LEFT = 9,
-    PERCENT_RIGHT = 10,
-    PERCENT_NONASSOC = 11,
-    PERCENT_PRECEDENCE = 12,
-    PERCENT_PREC = 13,
-    PERCENT_DPREC = 14,
-    PERCENT_MERGE = 15,
-    PERCENT_CODE = 16,
-    PERCENT_DEFAULT_PREC = 17,
-    PERCENT_DEFINE = 18,
-    PERCENT_DEFINES = 19,
-    PERCENT_ERROR_VERBOSE = 20,
-    PERCENT_EXPECT = 21,
-    PERCENT_EXPECT_RR = 22,
-    PERCENT_FLAG = 23,
-    PERCENT_FILE_PREFIX = 24,
-    PERCENT_GLR_PARSER = 25,
-    PERCENT_INITIAL_ACTION = 26,
-    PERCENT_LANGUAGE = 27,
-    PERCENT_NAME_PREFIX = 28,
-    PERCENT_NO_DEFAULT_PREC = 29,
-    PERCENT_NO_LINES = 30,
-    PERCENT_NONDETERMINISTIC_PARSER = 31,
-    PERCENT_OUTPUT = 32,
-    PERCENT_PURE_PARSER = 33,
-    PERCENT_REQUIRE = 34,
-    PERCENT_SKELETON = 35,
-    PERCENT_START = 36,
-    PERCENT_TOKEN_TABLE = 37,
-    PERCENT_VERBOSE = 38,
-    PERCENT_YACC = 39,
-    BRACED_CODE = 40,
-    BRACED_PREDICATE = 41,
-    BRACKETED_ID = 42,
-    CHAR = 43,
-    COLON = 44,
-    EPILOGUE = 45,
-    EQUAL = 46,
-    ID = 47,
-    ID_COLON = 48,
-    PERCENT_PERCENT = 49,
-    PIPE = 50,
-    PROLOGUE = 51,
-    SEMICOLON = 52,
-    TAG = 53,
-    TAG_ANY = 54,
-    TAG_NONE = 55,
-    INT = 56,
-    PERCENT_PARAM = 57,
-    PERCENT_UNION = 58,
-    PERCENT_EMPTY = 59
+    TSTRING = 4,
+    PERCENT_TOKEN = 5,
+    PERCENT_NTERM = 6,
+    PERCENT_TYPE = 7,
+    PERCENT_DESTRUCTOR = 8,
+    PERCENT_PRINTER = 9,
+    PERCENT_LEFT = 10,
+    PERCENT_RIGHT = 11,
+    PERCENT_NONASSOC = 12,
+    PERCENT_PRECEDENCE = 13,
+    PERCENT_PREC = 14,
+    PERCENT_DPREC = 15,
+    PERCENT_MERGE = 16,
+    PERCENT_CODE = 17,
+    PERCENT_DEFAULT_PREC = 18,
+    PERCENT_DEFINE = 19,
+    PERCENT_DEFINES = 20,
+    PERCENT_ERROR_VERBOSE = 21,
+    PERCENT_EXPECT = 22,
+    PERCENT_EXPECT_RR = 23,
+    PERCENT_FLAG = 24,
+    PERCENT_FILE_PREFIX = 25,
+    PERCENT_GLR_PARSER = 26,
+    PERCENT_INITIAL_ACTION = 27,
+    PERCENT_LANGUAGE = 28,
+    PERCENT_NAME_PREFIX = 29,
+    PERCENT_NO_DEFAULT_PREC = 30,
+    PERCENT_NO_LINES = 31,
+    PERCENT_NONDETERMINISTIC_PARSER = 32,
+    PERCENT_OUTPUT = 33,
+    PERCENT_PURE_PARSER = 34,
+    PERCENT_REQUIRE = 35,
+    PERCENT_SKELETON = 36,
+    PERCENT_START = 37,
+    PERCENT_TOKEN_TABLE = 38,
+    PERCENT_VERBOSE = 39,
+    PERCENT_YACC = 40,
+    BRACED_CODE = 41,
+    BRACED_PREDICATE = 42,
+    BRACKETED_ID = 43,
+    CHAR = 44,
+    COLON = 45,
+    EPILOGUE = 46,
+    EQUAL = 47,
+    ID = 48,
+    ID_COLON = 49,
+    PERCENT_PERCENT = 50,
+    PIPE = 51,
+    PROLOGUE = 52,
+    SEMICOLON = 53,
+    TAG = 54,
+    TAG_ANY = 55,
+    TAG_NONE = 56,
+    INT = 57,
+    PERCENT_PARAM = 58,
+    PERCENT_UNION = 59,
+    PERCENT_EMPTY = 60
   };
 #endif
 
@@ -147,6 +148,8 @@ union GRAM_STYPE
   assoc precedence_declarator;
   /* "string"  */
   char* STRING;
+  /* "translatable string"  */
+  char* TSTRING;
   /* "{...}"  */
   char* BRACED_CODE;
   /* "%?{...}"  */
@@ -160,13 +163,15 @@ union GRAM_STYPE
   /* "integer"  */
   int INT;
   /* int.opt  */
-  int yytype_81;
+  int yytype_82;
   /* named_ref.opt  */
-  named_ref* yytype_93;
+  named_ref* yytype_95;
   /* "%param"  */
   param_type PERCENT_PARAM;
   /* token_decl  */
   symbol* token_decl;
+  /* alias  */
+  symbol* alias;
   /* token_decl_for_prec  */
   symbol* token_decl_for_prec;
   /* id  */
@@ -177,8 +182,6 @@ union GRAM_STYPE
   symbol* symbol;
   /* string_as_id  */
   symbol* string_as_id;
-  /* string_as_id.opt  */
-  symbol* yytype_100;
   /* generic_symlist  */
   symbol_list* generic_symlist;
   /* generic_symlist_item  */
@@ -188,15 +191,15 @@ union GRAM_STYPE
   /* token_decls  */
   symbol_list* token_decls;
   /* token_decl.1  */
-  symbol_list* yytype_79;
+  symbol_list* yytype_80;
   /* token_decls_for_prec  */
   symbol_list* token_decls_for_prec;
   /* token_decl_for_prec.1  */
-  symbol_list* yytype_83;
+  symbol_list* yytype_85;
   /* symbol_decls  */
   symbol_list* symbol_decls;
   /* symbol_decl.1  */
-  symbol_list* yytype_86;
+  symbol_list* yytype_88;
   /* "%error-verbose"  */
   uniqstr PERCENT_ERROR_VERBOSE;
   /* "%<flag>"  */
@@ -216,7 +219,7 @@ union GRAM_STYPE
   /* "<tag>"  */
   uniqstr TAG;
   /* tag.opt  */
-  uniqstr yytype_73;
+  uniqstr yytype_74;
   /* tag  */
   uniqstr tag;
   /* variable  */

--- a/src/parse-gram.y
+++ b/src/parse-gram.y
@@ -125,7 +125,7 @@
 %define api.token.raw
 %define api.value.type union
 %define locations
-%define parse.error verbose
+%define parse.error detailed
 %define parse.lac full
 %define parse.trace
 %defines

--- a/src/scan-gram.l
+++ b/src/scan-gram.l
@@ -110,8 +110,8 @@ static void unexpected_newline (boundary, char const *);
 %}
  /* A C-like comment in directives/rules. */
 %x SC_YACC_COMMENT
- /* Strings and characters in directives/rules. */
-%x SC_ESCAPED_STRING SC_ESCAPED_CHARACTER
+ /* Characters and strings in directives/rules. */
+%x SC_ESCAPED_CHARACTER SC_ESCAPED_STRING SC_ESCAPED_TSTRING
  /* A identifier was just read in directives/rules.  Special state
     to capture the sequence 'identifier :'. */
 %x SC_AFTER_IDENTIFIER
@@ -318,6 +318,7 @@ eqopt    ({sp}=)?
 
   /* Strings. */
   "\""        token_start = loc->start; BEGIN SC_ESCAPED_STRING;
+  "_(\""      token_start = loc->start; BEGIN SC_ESCAPED_TSTRING;
 
   /* Prologue. */
   "%{"        code_start = loc->start; BEGIN SC_PROLOGUE;
@@ -378,7 +379,7 @@ eqopt    ({sp}=)?
   | added value.                                                  |
   `--------------------------------------------------------------*/
 
-<SC_ESCAPED_CHARACTER,SC_ESCAPED_STRING,SC_TAG>
+<SC_ESCAPED_CHARACTER,SC_ESCAPED_STRING,SC_ESCAPED_TSTRING,SC_TAG>
 {
   \0        complain (loc, complaint, _("invalid null character"));
 }
@@ -539,6 +540,20 @@ eqopt    ({sp}=)?
   {eol}     unexpected_newline (token_start, "\"");
 }
 
+<SC_ESCAPED_TSTRING>
+{
+  "\")" {
+    STRING_FINISH;
+    BEGIN INITIAL;
+    loc->start = token_start;
+    complain (loc, Wyacc,
+              _("POSIX Yacc does not support string literals"));
+    RETURN_VALUE (TSTRING, last_string);
+  }
+  <<EOF>>   unexpected_eof (token_start, "\"");
+  "\n"      unexpected_newline (token_start, "\"");
+}
+
   /*----------------------------------------------------------.
   | Scanning a Bison character literal, decoding its escapes. |
   | The initial quote is already eaten.                       |
@@ -601,7 +616,7 @@ eqopt    ({sp}=)?
   | Decode escaped characters.  |
   `----------------------------*/
 
-<SC_ESCAPED_STRING,SC_ESCAPED_CHARACTER>
+<SC_ESCAPED_CHARACTER,SC_ESCAPED_STRING,SC_ESCAPED_TSTRING>
 {
   \\[0-7]{1,3} {
     verify (UCHAR_MAX < ULONG_MAX);
@@ -797,7 +812,7 @@ eqopt    ({sp}=)?
   | By default, grow the string obstack with the input.  |
   `-----------------------------------------------------*/
 
-<SC_COMMENT,SC_LINE_COMMENT,SC_BRACED_CODE,SC_PREDICATE,SC_PROLOGUE,SC_EPILOGUE,SC_STRING,SC_CHARACTER,SC_ESCAPED_STRING,SC_ESCAPED_CHARACTER>
+<SC_COMMENT,SC_LINE_COMMENT,SC_BRACED_CODE,SC_PREDICATE,SC_PROLOGUE,SC_EPILOGUE,SC_STRING,SC_CHARACTER,SC_ESCAPED_CHARACTER,SC_ESCAPED_STRING,SC_ESCAPED_TSTRING>
 {
   /* Accept multibyte characters in one block instead of byte after
      byte, so that add_column_width and mbsnwidth can compute correct

--- a/src/symtab.c
+++ b/src/symtab.c
@@ -109,6 +109,7 @@ symbol_new (uniqstr tag, location loc)
 
   res->tag = tag;
   res->location = loc;
+  res->translatable = false;
   res->location_of_lhs = false;
   res->alias = NULL;
   res->content = sym_content_new (res);
@@ -954,7 +955,7 @@ dummy_symbol_get (location loc)
 }
 
 bool
-symbol_is_dummy (const symbol *sym)
+symbol_is_dummy (symbol const *sym)
 {
   return sym->tag[0] == '@' || (sym->tag[0] == '$' && sym->tag[1] == '@');
 }

--- a/src/symtab.h
+++ b/src/symtab.h
@@ -97,6 +97,9 @@ struct symbol
   /** The "defining" location.  */
   location location;
 
+  /** Whether this symbol is translatable. */
+  bool translatable;
+
   /** Whether \a location is about the first uses as left-hand side
       symbol of a rule (true), or simply the first occurrence (e.g.,
       in a %type, or as a rhs symbol of a rule).  The former type of
@@ -117,6 +120,8 @@ struct symbol
 
 struct sym_content
 {
+  /** The main symbol that denotes this content (it contains the
+      possible alias). */
   symbol *symbol;
 
   /** Its \c \%type.
@@ -179,7 +184,7 @@ symbol *dummy_symbol_get (location loc);
 void symbol_print (symbol const *s, FILE *f);
 
 /** Is this a dummy nonterminal?  */
-bool symbol_is_dummy (const symbol *sym);
+bool symbol_is_dummy (symbol const *sym);
 
 /** The name of the code_props type: "\%destructor" or "\%printer".  */
 char const *code_props_type_string (code_props_type kind);

--- a/tests/calc.at
+++ b/tests/calc.at
@@ -25,6 +25,9 @@
 
 m4_pushdef([AT_CALC_MAIN],   [AT_LANG_DISPATCH([$0], $@)])
 
+m4_pushdef([AT_TOKEN_TRANSLATE_IF],
+[AT_ERROR_CUSTOM_IF([$1], [AT_ERROR_DETAILED_IF([$1], [$2])])])
+
 m4_define([AT_CALC_MAIN(c)],
 [[#include <assert.h>
 #include <unistd.h>
@@ -417,6 +420,21 @@ void location_print (FILE *o, Span s);
 
   ]AT_YYERROR_DECLARE[
   ]AT_YYLEX_DECLARE_EXTERN[
+
+  ]AT_TOKEN_TRANSLATE_IF([[
+    static
+    const char *
+    _ (const char *cp)
+    {
+      /* Make sure only "end of input" is translated.  */
+      if (strcmp (cp, "end of input") == 0)
+        return "end of file";
+      else if (strcmp (cp, "number") == 0)
+        return "nombre";
+      else
+        return cp;
+    }
+  ]])[
 }
 ]])[
 
@@ -428,8 +446,8 @@ void location_print (FILE *o, Span s);
 }]])[
 
 /* Bison Declarations */
-%token CALC_EOF 0 "end of input"
-%token <ival> NUM "number"
+%token CALC_EOF 0 _("end of input")
+%token <ival> NUM   "number"
 %type  <ival> exp
 
 %nonassoc '='   /* comparison          */
@@ -523,6 +541,7 @@ AT_DATA_SOURCE([[calc-main.]AT_LANG_EXT],
 
 ]AT_CALC_MAIN])
 ])
+
 ])# _AT_DATA_CALC_Y
 
 
@@ -712,12 +731,12 @@ _AT_CHECK_CALC_ERROR([$1], [1],
 +1],
                      [[final: 0 0 1]],
                      [20],
-                     [[2.1: syntax error on token ['+'] (expected: [end of input] [number] ['-'] ['\n'] ['('] ['!'])]])
+                     [[2.1: syntax error on token ['+'] (expected: ]AT_TOKEN_TRANSLATE_IF([[[end of file]]], [[[end of input]]])[ [number] ['-'] ['\n'] ['('] ['!'])]])
 # Exercise error messages with EOF: work on an empty file.
 _AT_CHECK_CALC_ERROR([$1], [1], [/dev/null],
                      [[final: 0 0 1]],
                      [4],
-                     [[1.1: syntax error on token [end of input] (expected: [number] ['-'] ['\n'] ['('] ['!'])]])
+                     [[1.1: syntax error on token ]AT_TOKEN_TRANSLATE_IF([[[end of file]]], [[[end of input]]])[ (expected: [number] ['-'] ['\n'] ['('] ['!'])]])
 
 # Exercise the error token: without it, we die at the first error,
 # hence be sure to
@@ -968,5 +987,6 @@ AT_CHECK_CALC_LALR1_D([%define parse.error verbose %debug %verbose])
 #AT_CHECK_CALC_LALR1_D([%locations %define parse.error verbose %debug %verbose %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 #AT_CHECK_CALC_LALR1_D([%locations %define parse.error verbose %debug %define api.prefix {calc} %verbose %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 
+m4_popdef([AT_TOKEN_TRANSLATE_IF])
 m4_popdef([AT_CALC_MAIN])
 m4_popdef([AT_CALC_YYLEX])

--- a/tests/calc.at
+++ b/tests/calc.at
@@ -616,10 +616,10 @@ mv at-expout expout]])
 # the traditional one.
 AT_ERROR_CUSTOM_IF([], [
 AT_PERL_REQUIRE([[-pi -e 'use strict;
-  s{syntax error on token \["?(.*?)"?\] \(expected: (.*)\)}
+  s{syntax error on token \[(.*?)\] \(expected: (.*)\)}
   {
     my $unexp = $][1;
-    my @exps = $][2 =~ /\["?(.*?)"?\]/g;
+    my @exps = $][2 =~ /\[(.*?)\]/g;
     ($][#exps && $][#exps < 4)
     ? "syntax error, unexpected $unexp, expecting @{[join(\" or \", @exps)]}"
     : "syntax error, unexpected $unexp";
@@ -694,15 +694,15 @@ _AT_CHECK_CALC([$1],
 _AT_CHECK_CALC_ERROR([$1], [1], [1 2],
                      [[final: 0 0 1]],
                      [15],
-                     [[1.3: syntax error on token ["number"] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] ['\n'])]])
+                     [[1.3: syntax error on token [number] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] ['\n'])]])
 _AT_CHECK_CALC_ERROR([$1], [1], [1//2],
                      [[final: 0 0 1]],
                      [20],
-                     [[1.3: syntax error on token ['/'] (expected: ["number"] ['-'] ['('] ['!'])]])
+                     [[1.3: syntax error on token ['/'] (expected: [number] ['-'] ['('] ['!'])]])
 _AT_CHECK_CALC_ERROR([$1], [1], [error],
                      [[final: 0 0 1]],
                      [5],
-                     [[1.1: syntax error on token [$undefined] (expected: ["number"] ['-'] ['\n'] ['('] ['!'])]])
+                     [[1.1: syntax error on token [$undefined] (expected: [number] ['-'] ['\n'] ['('] ['!'])]])
 _AT_CHECK_CALC_ERROR([$1], [1], [1 = 2 = 3],
                      [[final: 0 0 1]],
                      [30],
@@ -712,12 +712,12 @@ _AT_CHECK_CALC_ERROR([$1], [1],
 +1],
                      [[final: 0 0 1]],
                      [20],
-                     [[2.1: syntax error on token ['+'] (expected: ["end of input"] ["number"] ['-'] ['\n'] ['('] ['!'])]])
+                     [[2.1: syntax error on token ['+'] (expected: [end of input] [number] ['-'] ['\n'] ['('] ['!'])]])
 # Exercise error messages with EOF: work on an empty file.
 _AT_CHECK_CALC_ERROR([$1], [1], [/dev/null],
                      [[final: 0 0 1]],
                      [4],
-                     [[1.1: syntax error on token ["end of input"] (expected: ["number"] ['-'] ['\n'] ['('] ['!'])]])
+                     [[1.1: syntax error on token [end of input] (expected: [number] ['-'] ['\n'] ['('] ['!'])]])
 
 # Exercise the error token: without it, we die at the first error,
 # hence be sure to
@@ -739,10 +739,10 @@ _AT_CHECK_CALC_ERROR([$1], [0],
                      [() + (1 + 1 + 1 +) + (* * *) + (1 * 2 * *) = 1],
                      [[final: 4444 0 4]],
                      [250],
-[[1.2: syntax error on token [')'] (expected: ["number"] ['-'] ['('] ['!'])
-1.18: syntax error on token [')'] (expected: ["number"] ['-'] ['('] ['!'])
-1.23: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
-1.41: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
+[[1.2: syntax error on token [')'] (expected: [number] ['-'] ['('] ['!'])
+1.18: syntax error on token [')'] (expected: [number] ['-'] ['('] ['!'])
+1.23: syntax error on token ['*'] (expected: [number] ['-'] ['('] ['!'])
+1.41: syntax error on token ['*'] (expected: [number] ['-'] ['('] ['!'])
 calc: error: 4444 != 1]])
 
 # The same, but this time exercising explicitly triggered syntax errors.
@@ -750,13 +750,13 @@ calc: error: 4444 != 1]])
 _AT_CHECK_CALC_ERROR([$1], [0], [(!) + (1 2) = 1],
                      [[final: 2222 0 1]],
                      [102],
-[[1.10: syntax error on token ["number"] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] [')'])
+[[1.10: syntax error on token [number] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] [')'])
 calc: error: 2222 != 1]])
 _AT_CHECK_CALC_ERROR([$1], [0], [(- *) + (1 2) = 1],
                      [[final: 2222 0 2]],
                      [113],
-[[1.4: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
-1.12: syntax error on token ["number"] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] [')'])
+[[1.4: syntax error on token ['*'] (expected: [number] ['-'] ['('] ['!'])
+1.12: syntax error on token [number] (expected: ['='] ['-'] ['+'] ['*'] ['/'] ['^'] [')'])
 calc: error: 2222 != 1]])
 
 # Check that yyerrok works properly: second error is not reported,
@@ -764,9 +764,9 @@ calc: error: 2222 != 1]])
 _AT_CHECK_CALC_ERROR([$1], [0], [(* *) + (*) + (*)],
                      [[final: 3333 0 3]],
                      [113],
-[[1.2: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
-1.10: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])
-1.16: syntax error on token ['*'] (expected: ["number"] ['-'] ['('] ['!'])]])
+[[1.2: syntax error on token ['*'] (expected: [number] ['-'] ['('] ['!'])
+1.10: syntax error on token ['*'] (expected: [number] ['-'] ['('] ['!'])
+1.16: syntax error on token ['*'] (expected: [number] ['-'] ['('] ['!'])]])
 
 AT_BISON_OPTION_POPDEFS
 

--- a/tests/calc.at
+++ b/tests/calc.at
@@ -798,24 +798,26 @@ AT_CHECK_CALC_LALR([%locations %define api.location.type {Span}])
 AT_CHECK_CALC_LALR([%name-prefix "calc"])
 AT_CHECK_CALC_LALR([%verbose])
 AT_CHECK_CALC_LALR([%yacc])
+AT_CHECK_CALC_LALR([%define parse.error detailed])
 AT_CHECK_CALC_LALR([%define parse.error verbose])
 
 AT_CHECK_CALC_LALR([%define api.pure full %locations])
 AT_CHECK_CALC_LALR([%define api.push-pull both %define api.pure full %locations])
-AT_CHECK_CALC_LALR([%define parse.error verbose %locations])
+AT_CHECK_CALC_LALR([%define parse.error detailed %locations])
 
-AT_CHECK_CALC_LALR([%define parse.error verbose %locations %defines %define api.prefix {calc} %verbose %yacc])
-AT_CHECK_CALC_LALR([%define parse.error verbose %locations %defines %name-prefix "calc" %define api.token.prefix {TOK_} %verbose %yacc])
+AT_CHECK_CALC_LALR([%define parse.error detailed %locations %defines %define api.prefix {calc} %verbose %yacc])
+AT_CHECK_CALC_LALR([%define parse.error detailed %locations %defines %name-prefix "calc" %define api.token.prefix {TOK_} %verbose %yacc])
 
 AT_CHECK_CALC_LALR([%debug])
-AT_CHECK_CALC_LALR([%define parse.error verbose %debug %locations %defines %name-prefix "calc" %verbose %yacc])
-AT_CHECK_CALC_LALR([%define parse.error verbose %debug %locations %defines %define api.prefix {calc} %verbose %yacc])
+AT_CHECK_CALC_LALR([%define parse.error detailed %debug %locations %defines %name-prefix "calc" %verbose %yacc])
+AT_CHECK_CALC_LALR([%define parse.error detailed %debug %locations %defines %define api.prefix {calc} %verbose %yacc])
 
-AT_CHECK_CALC_LALR([%define api.pure full %define parse.error verbose %debug %locations %defines %name-prefix "calc" %verbose %yacc])
-AT_CHECK_CALC_LALR([%define api.push-pull both %define api.pure full %define parse.error verbose %debug %locations %defines %define api.prefix {calc} %verbose %yacc])
+AT_CHECK_CALC_LALR([%define api.pure full %define parse.error detailed %debug %locations %defines %name-prefix "calc" %verbose %yacc])
+AT_CHECK_CALC_LALR([%define api.push-pull both %define api.pure full %define parse.error detailed %debug %locations %defines %define api.prefix {calc} %verbose %yacc])
 
-AT_CHECK_CALC_LALR([%define api.pure %define parse.error verbose %debug %locations %defines %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}{int *nerrs}])
+AT_CHECK_CALC_LALR([%define api.pure %define parse.error detailed %debug %locations %defines %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 
+AT_CHECK_CALC_LALR([%no-lines %define api.pure %define parse.error detailed %debug %locations %defines %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 AT_CHECK_CALC_LALR([%no-lines %define api.pure %define parse.error verbose %debug %locations %defines %define api.prefix {calc} %verbose %yacc %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 
 

--- a/tests/calc.at
+++ b/tests/calc.at
@@ -422,6 +422,7 @@ void location_print (FILE *o, Span s);
   ]AT_YYLEX_DECLARE_EXTERN[
 
   ]AT_TOKEN_TRANSLATE_IF([[
+#define N_
     static
     const char *
     _ (const char *cp)

--- a/tests/local.at
+++ b/tests/local.at
@@ -206,10 +206,12 @@ m4_pushdef([AT_DEBUG_IF],
            [m4_bmatch([$3], [%debug\|%define parse.trace], [$1], [$2])])
 m4_pushdef([AT_ERROR_CUSTOM_IF],
            [m4_bmatch([$3], [%define parse\.error custom], [$1], [$2])])
+m4_pushdef([AT_ERROR_DETAILED_IF],
+           [m4_bmatch([$3], [%define parse\.error detailed], [$1], [$2])])
 m4_pushdef([AT_ERROR_VERBOSE_IF],
            [m4_bmatch([$3], [%define parse\.error verbose], [$1], [$2])])
 m4_pushdef([AT_ERROR_SIMPLE_IF],
-           [AT_ERROR_CUSTOM_IF([$2], [AT_ERROR_VERBOSE_IF([$2], [$1])], [$1])])
+           [AT_ERROR_CUSTOM_IF([$2], [AT_ERROR_DETAILED_IF([$2], [AT_ERROR_VERBOSE_IF([$2], [$1])], [$1])], [$1])])
 m4_pushdef([AT_CXX_IF],
 [m4_bmatch([$3], [%language "[Cc]\+\+"\|%skeleton "[a-z0-9]+\.cc"], [$1], [$2])])
 m4_pushdef([AT_D_IF],
@@ -417,6 +419,7 @@ m4_popdef([AT_GLR_CC_IF])
 m4_popdef([AT_LALR1_CC_IF])
 m4_popdef([AT_ERROR_SIMPLE_IF])
 m4_popdef([AT_ERROR_VERBOSE_IF])
+m4_popdef([AT_ERROR_DETAILED_IF])
 m4_popdef([AT_ERROR_CUSTOM_IF])
 m4_popdef([AT_DEBUG_IF])
 m4_popdef([AT_DEFINES_IF])

--- a/tests/regression.at
+++ b/tests/regression.at
@@ -366,17 +366,17 @@ AT_CLEANUP
 ## Token definitions.  ##
 ## ------------------- ##
 
+m4_pushdef([AT_TEST],
+[AT_SETUP([Token definitions: $1])
 
-AT_SETUP([Token definitions])
-
-AT_BISON_OPTION_PUSHDEFS
+AT_BISON_OPTION_PUSHDEFS([$1])
 
 AT_DATA_GRAMMAR([input.y],
 [%{
 ]AT_YYERROR_DECLARE[
 ]AT_YYLEX_DECLARE[
 %}
-[%define parse.error verbose
+[$1
 %token MYEOF 0 "end of file"
 %token 'a' "a"  // Bison managed, when fed with '%token 'f' "f"' to #define 'f'!
 %token B_TOKEN "b"
@@ -391,7 +391,6 @@ exp: "a" "\\\'\?\"\a\b\f\n\r\t\v\001\201\x001\x000081??!";
 ]AT_YYLEX_DEFINE([{ SPECIAL }])[
 ]AT_MAIN_DEFINE[
 ]])
-AT_BISON_OPTION_POPDEFS
 
 # Checking the warning message guarantees that the trigraph "??!" isn't
 # unnecessarily escaped here even though it would need to be if encoded in a
@@ -411,6 +410,7 @@ input.y:22.16-63: warning: symbol "\\'?\"\a\b\f\n\r\t\v\001\201\001\201??!" used
 
 AT_COMPILE([input])
 
+AT_ERROR_VERBOSE_IF([
 # Checking the error message here guarantees that yytname, which does contain
 # C-string literals, does have the trigraph escaped correctly.  Thus, the
 # symbol name reported by the parser is exactly the same as that reported by
@@ -419,9 +419,20 @@ AT_DATA([experr],
 [[syntax error, unexpected "\\'?\"\a\b\f\n\r\t\v\001\201\001\201??!", expecting a
 ]])
 AT_PARSER_CHECK([input], 1, [], [experr])
+])
+
+# We don't check the error message in "detailed" parse.error, since
+# the special characters are no longer escaped, and it produces
+# invalid UTF-8.
+
+AT_BISON_OPTION_POPDEFS
 AT_CLEANUP
+])
 
+AT_TEST([%define parse.error detailed])
+AT_TEST([%define parse.error verbose])
 
+m4_popdef([AT_TEST])
 
 ## -------------------- ##
 ## Characters Escapes.  ##

--- a/tests/regression.at
+++ b/tests/regression.at
@@ -385,10 +385,10 @@ AT_DATA_GRAMMAR([input.y],
 %token SPECIAL "\\\'\?\"\a\b\f\n\r\t\v\001\201\x001\x000081??!"
 %token SPECIAL "\\\'\?\"\a\b\f\n\r\t\v\001\201\x001\x000081??!"
 %%
-exp: "a" "\\\'\?\"\a\b\f\n\r\t\v\001\201\x001\x000081??!";
+exp: ]AT_ERROR_VERBOSE_IF(["\\\'\?\"\a\b\f\n\r\t\v\001\201\x001\x000081??!"], ["∃¬∩∪∀"])[;
 %%
 ]AT_YYERROR_DEFINE[
-]AT_YYLEX_DEFINE([{ SPECIAL }])[
+]AT_YYLEX_DEFINE(["a"])[
 ]AT_MAIN_DEFINE[
 ]])
 
@@ -410,20 +410,13 @@ input.y:22.16-63: warning: symbol "\\'?\"\a\b\f\n\r\t\v\001\201\001\201??!" used
 
 AT_COMPILE([input])
 
-AT_ERROR_VERBOSE_IF([
 # Checking the error message here guarantees that yytname, which does contain
 # C-string literals, does have the trigraph escaped correctly.  Thus, the
 # symbol name reported by the parser is exactly the same as that reported by
 # Bison itself.
-AT_DATA([experr],
-[[syntax error, unexpected "\\'?\"\a\b\f\n\r\t\v\001\201\001\201??!", expecting a
+AT_PARSER_CHECK([input], 1, [],
+[[syntax error, unexpected a, expecting ]AT_ERROR_VERBOSE_IF([["\\'?\"\a\b\f\n\r\t\v\001\201\001\201??!"]], [[∃¬∩∪∀]])[
 ]])
-AT_PARSER_CHECK([input], 1, [], [experr])
-])
-
-# We don't check the error message in "detailed" parse.error, since
-# the special characters are no longer escaped, and it produces
-# invalid UTF-8.
 
 AT_BISON_OPTION_POPDEFS
 AT_CLEANUP


### PR DESCRIPTION
This series of patches builds on top of the previous one (https://lists.gnu.org/r/bison-patches/2020-01/msg00044.html).  It brings the following features with parse.error=custom or detailed (which I prefer to my previous proposal, 'rich').

Comments and feedback would be most useful.  It is again also available on Savannah, and here: https://github.com/akimd/bison/pull/22.

1.  Faithfulness

The token strings are no longer doubly-quoted, and no longer depend on the current locale.  So for instance
```C
%token MAXWELL "∇⃗×𝐸⃗ = -∂𝐵⃗/∂t"
```
gives with an UTF-8 able locale
```c
static const char *const yytname[] =
{
  "$end", "error", "$undefined", "\"∇⃗×𝐸⃗ = -∂𝐵⃗/∂t\"",
  "$accept", "e", YY_NULLPTR
};
```
With the C locale, you get
```c
static const char *const yytname[] =
{
  "$end", "error", "$undefined",
  "\"\\342\\210\\207\\342\\203\\227\\303\\227\\360\\235\\220\\270\\342\\203\\227 = -\\342\\210\\202\\360\\235\\220\\265\\342\\203\\227/\\342\\210\\202t\"",
  "$accept", "e", YY_NULLPTR
};
```
With custom/detailed, you always get
``` C
  static const char *const yy_sname[] =
  {
  "$end", "error", "$undefined", "∇⃗×𝐸⃗ = -∂𝐵⃗/∂t",
  "$accept", "e", YY_NULLPTR
  };
```

2.  Internationalization

Token aliases can be (selectively) translated.  For instance in the gramnar file
```c
%token NUMBER _("number")
```
in which case the yysymbol_name function returns `_("number")` instead of "number".  It is the user responsibility to define a `_` function (and `N_`).
