### PR TITLE
larlr1.cc: Reject unsupported values for parse.lac

### DIFF
--- a/data/skeletons/lalr1.cc
+++ b/data/skeletons/lalr1.cc
@@ -23,6 +23,7 @@ m4_define([b4_value_type_setup_variant])
 # Check the value of %define parse.lac, where LAC stands for lookahead
 # correction.
 b4_percent_define_default([[parse.lac]], [[none]])
+b4_percent_define_check_values([[[[parse.lac]], [[full]], [[none]]]])
 b4_define_flag_if([lac])
 m4_define([b4_lac_flag],
           [m4_if(b4_percent_define_get([[parse.lac]]),

--- a/tests/input.at
+++ b/tests/input.at
@@ -2367,6 +2367,25 @@ AT_DATA([[input.y]],
 start: %empty;
 ]])
 
+# Only "full" and "none" are accepted for parse.lac
+# Unknown values (such as "unsupported") are rejected
+AT_BISON_CHECK([[-Dparse.lac=none input.y]])
+AT_BISON_CHECK([[-Dparse.lac=none -L c++ input.y]])
+AT_BISON_CHECK([[-Dparse.lac=full input.y]])
+AT_BISON_CHECK([[-Dparse.lac=full -L c++ input.y]])
+AT_BISON_CHECK([[-Dparse.lac=unsupported input.y]],
+               [[1]], [],
+[[<command line>:3: error: invalid value for %define variable 'parse.lac': 'unsupported'
+<command line>:3:     accepted value: 'full'
+<command line>:3:     accepted value: 'none'
+]])
+AT_BISON_CHECK([[-Dparse.lac=unsupported -L c++ input.y]],
+               [[1]], [],
+[[<command line>:3: error: invalid value for %define variable 'parse.lac': 'unsupported'
+<command line>:3:     accepted value: 'full'
+<command line>:3:     accepted value: 'none'
+]])
+
 # parse.lac.* options are useless if LAC isn't actually activated.
 AT_BISON_CHECK([[-Dparse.lac.es-capacity-initial=1 input.y]],
                [[1]], [],
@@ -2378,11 +2397,11 @@ AT_BISON_CHECK([[-Dparse.lac.memory-trace=full input.y]],
 ]])
 
 # parse.lac.* options are useless in C++ even if LAC isn't actually activated.
-AT_BISON_CHECK([[-Dparse.lac.es-capacity-initial=1 -L C++ -Dparse.lac input.y]],
+AT_BISON_CHECK([[-Dparse.lac.es-capacity-initial=1 -L C++ -Dparse.lac=full input.y]],
                [[1]], [],
 [[<command line>:3: error: %define variable 'parse.lac.es-capacity-initial' is not used
 ]])
-AT_BISON_CHECK([[-Dparse.lac.memory-trace=full -L C++ -Dparse.lac  input.y]],
+AT_BISON_CHECK([[-Dparse.lac.memory-trace=full -L C++ -Dparse.lac=full input.y]],
                [[1]], [],
 [[<command line>:3: error: %define variable 'parse.lac.memory-trace' is not used
 ]])


### PR DESCRIPTION
Just as the yacc.c skeleton, the lalr1.cc skeleton should reject
reject invalid value for parse.lac.

* data/skeletons/lalr1.cc: check validity of parse.lac
* tests/input.at: new test cases