### PR TITLE
Java: add support for parse.error custom|detailed

### DIFF
--- a/TODO
+++ b/TODO
@@ -12,6 +12,11 @@ The calc.at test should call yyerror with location:
       yyerror (]AT_LOCATION_IF([[@$, ]])["calc: error: " + $1 + " != " + $3);
   }
 
+** Java: EOF
+We should be able to redefine EOF like we do in C.
+
+** Java: calc.at
+Stop hard-coding "Calc".  Adjust local.at (look for FIXME).
 
 ** doc
 I feel it's ugly to use the GNU style to declare functions in the doc.  It

--- a/TODO
+++ b/TODO
@@ -18,6 +18,14 @@ We should be able to redefine EOF like we do in C.
 ** Java: calc.at
 Stop hard-coding "Calc".  Adjust local.at (look for FIXME).
 
+** Java: _
+We must not use _ in Java, it is becoming a keyword in Java 9.
+
+examples/java/calc/Calc.java:998: warning: '_' used as an identifier
+  "$end", "error", "$undefined", _("end of line"), _("number"), "'='",
+                                 ^
+  (use of '_' as an identifier might not be supported in releases after Java SE 8)
+
 ** doc
 I feel it's ugly to use the GNU style to declare functions in the doc.  It
 generates tons of white space in the page, and may contribute to bad page

--- a/data/skeletons/bison.m4
+++ b/data/skeletons/bison.m4
@@ -532,9 +532,9 @@ m4_define([b4_any_token_visible_if],
 # ----------------------------
 m4_define([b4_token_format],
 [b4_token_visible_if([$2],
-[m4_quote(m4_format([$1],
-                     [b4_symbol([$2], [id])],
-                     [b4_symbol([$2], b4_api_token_raw_if([[number]], [[user_number]]))]))])])
+[m4_format([[$1]],
+           m4_quote(b4_symbol([$2], [id])),
+           m4_quote(b4_symbol([$2], b4_api_token_raw_if([[number]], [[user_number]]))))])])
 
 
 ## ------- ##

--- a/data/skeletons/c.m4
+++ b/data/skeletons/c.m4
@@ -470,6 +470,13 @@ m4_define([b4_token_enums_defines],
 [b4_token_enums[]b4_yacc_if([b4_token_defines])])
 
 
+# b4_symbol_translate(STRING)
+# ---------------------------
+m4_define([b4_symbol_translate],
+[[N_($1)]])
+
+
+
 ## ----------------- ##
 ## Semantic Values.  ##
 ## ----------------- ##

--- a/data/skeletons/java.m4
+++ b/data/skeletons/java.m4
@@ -226,6 +226,13 @@ m4_define([b4_symbol_translate],
 [[_($1)]])
 
 
+# b4_trans(STRING)
+# ----------------
+# Translate a symbol.  Avoid collision with b4_translate.
+m4_define([b4_trans],
+[m4_if(b4_has_translations, 0, [$1], [_($1)])])
+
+
 
 # b4_symbol_value(VAL, [SYMBOL-NUM], [TYPE-TAG])
 # ----------------------------------------------

--- a/data/skeletons/java.m4
+++ b/data/skeletons/java.m4
@@ -220,6 +220,13 @@ m4_define([b4_position_type], [b4_percent_define_get([[api.position.type]])])
 ## ----------------- ##
 
 
+# b4_symbol_translate(STRING)
+# ---------------------------
+m4_define([b4_symbol_translate],
+[[_($1)]])
+
+
+
 # b4_symbol_value(VAL, [SYMBOL-NUM], [TYPE-TAG])
 # ----------------------------------------------
 # See README.

--- a/data/skeletons/lalr1.java
+++ b/data/skeletons/lalr1.java
@@ -945,18 +945,18 @@ b4_dollar_popdef[]dnl
         String[] yystr = new String[yycount];
         for (int yyi = 0; yyi < yycount; ++yyi)
           yystr[yyi] = yysymbolName (yyarg[yyi]);
-        MessageFormat yyformat;
+        String yyformat;
         switch (yycount)
           {
             default:
-            case 0: yyformat = new MessageFormat ("syntax error"); break;
-            case 1: yyformat = new MessageFormat ("syntax error, unexpected {0}"); break;
-            case 2: yyformat = new MessageFormat ("syntax error, unexpected {0}, expecting {1}"); break;
-            case 3: yyformat = new MessageFormat ("syntax error, unexpected {0}, expecting {1} or {2}"); break;
-            case 4: yyformat = new MessageFormat ("syntax error, unexpected {0}, expecting {1} or {2} or {3}"); break;
-            case 5: yyformat = new MessageFormat ("syntax error, unexpected {0}, expecting {1} or {2} or {3} or {4}"); break;
+            case 0: yyformat = ]b4_trans(["syntax error"])[; break;
+            case 1: yyformat = ]b4_trans(["syntax error, unexpected {0}"])[; break;
+            case 2: yyformat = ]b4_trans(["syntax error, unexpected {0}, expecting {1}"])[; break;
+            case 3: yyformat = ]b4_trans(["syntax error, unexpected {0}, expecting {1} or {2}"])[; break;
+            case 4: yyformat = ]b4_trans(["syntax error, unexpected {0}, expecting {1} or {2} or {3}"])[; break;
+            case 5: yyformat = ]b4_trans(["syntax error, unexpected {0}, expecting {1} or {2} or {3} or {4}"])[; break;
           }
-        return yyformat.format (yystr);
+        return new MessageFormat (yyformat).format (yystr);
       }
 ]])[
     return "syntax error";

--- a/data/skeletons/lalr1.java
+++ b/data/skeletons/lalr1.java
@@ -82,6 +82,7 @@ m4_define([b4_define_state],[[
 ]])[
 ]b4_user_pre_prologue[
 ]b4_user_post_prologue[
+import java.text.MessageFormat;
 ]b4_percent_code_get([[imports]])[
 /**
  * A Bison parser, automatically generated from <tt>]m4_bpatsubst(b4_file_name, [^"\(.*\)"$], [\1])[</tt>.
@@ -673,7 +674,10 @@ b4_dollar_popdef[]dnl
             ++yynerrs;
             if (yychar == yyempty_)
               yytoken = yyempty_;
-            yyerror (]b4_locations_if([yylloc, ])[yysyntax_error (yystate, yytoken));
+            Context yyctx = new Context ();
+            yyctx.yystack = yystack;
+            yyctx.yytoken = yytoken;
+            yyerror (]b4_locations_if([yylloc, ])[yysyntax_error (yyctx));
           }
 
 ]b4_locations_if([[
@@ -851,74 +855,108 @@ b4_dollar_popdef[]dnl
   }
 ]])[
 
+  public final class Context
+  {
+    public YYStack yystack;
+    public int yytoken;
+  };
+
+  /* Put in YYARG at most YYARGN of the expected tokens given the
+     current YYCTX, and return the number of tokens stored in YYARG.  If
+     YYARG is null, return the number of expected tokens (guaranteed to
+     be less than YYNTOKENS).  */
+  static int
+  yyexpectedTokens (Context yyctx,
+                    int yyarg[], int yyoffset, int yyargn)
+  {
+    int yycount = yyoffset;
+    int yyn = yypact_[yyctx.yystack.stateAt (0)];
+    if (!yyPactValueIsDefault (yyn))
+      {
+        /* Start YYX at -YYN if negative to avoid negative
+           indexes in YYCHECK.  In other words, skip the first
+           -YYN actions for this state because they are default
+           actions.  */
+        int yyxbegin = yyn < 0 ? -yyn : 0;
+        /* Stay within bounds of both yycheck and yytname.  */
+        int yychecklim = yylast_ - yyn + 1;
+        int yyxend = yychecklim < yyntokens_ ? yychecklim : yyntokens_;
+        for (int x = yyxbegin; x < yyxend; ++x)
+          if (yycheck_[x + yyn] == x && x != yy_error_token_
+              && !yyTableValueIsError (yytable_[x + yyn]))
+            {
+              if (yyarg == null)
+                yycount += 1;
+              else if (yycount == yyargn)
+                return 0; // FIXME: this is incorrect.
+              else
+                yyarg[yycount++] = x;
+            }
+      }
+    return yycount - yyoffset;
+  }
+
+  static int
+  yysyntaxErrorArguments (Context yyctx,
+                          int[] yyarg, int yyargn)
+  {
+    /* There are many possibilities here to consider:
+       - If this state is a consistent state with a default action,
+         then the only way this function was invoked is if the
+         default action is an error action.  In that case, don't
+         check for expected tokens because there are none.
+       - The only way there can be no lookahead present (in tok) is
+         if this state is a consistent state with a default action.
+         Thus, detecting the absence of a lookahead is sufficient to
+         determine that there is no unexpected or expected token to
+         report.  In that case, just report a simple "syntax error".
+       - Don't assume there isn't a lookahead just because this
+         state is a consistent state with a default action.  There
+         might have been a previous inconsistent state, consistent
+         state with a non-default action, or user semantic action
+         that manipulated yychar.  (However, yychar is currently out
+         of scope during semantic actions.)
+       - Of course, the expected token list depends on states to
+         have correct lookahead information, and it depends on the
+         parser not to perform extra reductions after fetching a
+         lookahead from the scanner and before detecting a syntax
+         error.  Thus, state merging (from LALR or IELR) and default
+         reductions corrupt the expected token list.  However, the
+         list is correct for canonical LR with one exception: it
+         will still contain any token that will not be accepted due
+         to an error action in a later state.
+    */
+    int yycount = 0;
+    if (yyctx.yytoken != yyempty_)
+      {
+        yyarg[yycount++] = yyctx.yytoken;
+        yycount += yyexpectedTokens (yyctx, yyarg, 1, yyargn);
+      }
+    return yycount;
+  }
+
   // Generate an error message.
-  private String yysyntax_error (int yystate, int tok)
+  private String yysyntax_error (Context yyctx)
   {]b4_error_verbose_if([[
     if (yyErrorVerbose)
       {
-        /* There are many possibilities here to consider:
-           - If this state is a consistent state with a default action,
-             then the only way this function was invoked is if the
-             default action is an error action.  In that case, don't
-             check for expected tokens because there are none.
-           - The only way there can be no lookahead present (in tok) is
-             if this state is a consistent state with a default action.
-             Thus, detecting the absence of a lookahead is sufficient to
-             determine that there is no unexpected or expected token to
-             report.  In that case, just report a simple "syntax error".
-           - Don't assume there isn't a lookahead just because this
-             state is a consistent state with a default action.  There
-             might have been a previous inconsistent state, consistent
-             state with a non-default action, or user semantic action
-             that manipulated yychar.  (However, yychar is currently out
-             of scope during semantic actions.)
-           - Of course, the expected token list depends on states to
-             have correct lookahead information, and it depends on the
-             parser not to perform extra reductions after fetching a
-             lookahead from the scanner and before detecting a syntax
-             error.  Thus, state merging (from LALR or IELR) and default
-             reductions corrupt the expected token list.  However, the
-             list is correct for canonical LR with one exception: it
-             will still contain any token that will not be accepted due
-             to an error action in a later state.
-        */
-        if (tok != yyempty_)
+        int[] yyarg = new int[5];
+        int yycount = yysyntaxErrorArguments (yyctx, yyarg, 5);
+        String[] yystr = new String[yycount];
+        for (int yyi = 0; yyi < yycount; ++yyi)
+          yystr[yyi] = yysymbolName (yyarg[yyi]);
+        MessageFormat yyformat;
+        switch (yycount)
           {
-            /* FIXME: This method of building the message is not compatible
-               with internationalization.  */
-            StringBuffer res =
-              new StringBuffer ("syntax error, unexpected ");
-            res.append (yysymbolName (tok));
-            int yyn = yypact_[yystate];
-            if (!yyPactValueIsDefault (yyn))
-              {
-                /* Start YYX at -YYN if negative to avoid negative
-                   indexes in YYCHECK.  In other words, skip the first
-                   -YYN actions for this state because they are default
-                   actions.  */
-                int yyxbegin = yyn < 0 ? -yyn : 0;
-                /* Stay within bounds of both yycheck and yytname.  */
-                int yychecklim = yylast_ - yyn + 1;
-                int yyxend = yychecklim < yyntokens_ ? yychecklim : yyntokens_;
-                int count = 0;
-                for (int x = yyxbegin; x < yyxend; ++x)
-                  if (yycheck_[x + yyn] == x && x != yy_error_token_
-                      && !yyTableValueIsError (yytable_[x + yyn]))
-                    ++count;
-                if (count < 5)
-                  {
-                    count = 0;
-                    for (int x = yyxbegin; x < yyxend; ++x)
-                      if (yycheck_[x + yyn] == x && x != yy_error_token_
-                          && !yyTableValueIsError (yytable_[x + yyn]))
-                        {
-                          res.append (count++ == 0 ? ", expecting " : " or ");
-                          res.append (yysymbolName (x));
-                        }
-                  }
-              }
-            return res.toString ();
+            default:
+            case 0: yyformat = new MessageFormat ("syntax error"); break;
+            case 1: yyformat = new MessageFormat ("syntax error, unexpected {0}"); break;
+            case 2: yyformat = new MessageFormat ("syntax error, unexpected {0}, expecting {1}"); break;
+            case 3: yyformat = new MessageFormat ("syntax error, unexpected {0}, expecting {1} or {2}"); break;
+            case 4: yyformat = new MessageFormat ("syntax error, unexpected {0}, expecting {1} or {2} or {3}"); break;
+            case 5: yyformat = new MessageFormat ("syntax error, unexpected {0}, expecting {1} or {2} or {3} or {4}"); break;
           }
+        return yyformat.format (yystr);
       }
 ]])[
     return "syntax error";

--- a/data/skeletons/lalr1.java
+++ b/data/skeletons/lalr1.java
@@ -488,42 +488,6 @@ m4_define([b4_define_state],[[
     return YYNEWSTATE;
   }
 
-]b4_error_verbose_if([[
-  /* Return YYSTR after stripping away unnecessary quotes and
-     backslashes, so that it's suitable for yyerror.  The heuristic is
-     that double-quoting is unnecessary unless the string contains an
-     apostrophe, a comma, or backslash (other than backslash-backslash).
-     YYSTR is taken from yytname.  */
-  private final String yytnamerr_ (String yystr)
-  {
-    if (yystr.charAt (0) == '"')
-      {
-        StringBuffer yyr = new StringBuffer ();
-        strip_quotes: for (int i = 1; i < yystr.length (); i++)
-          switch (yystr.charAt (i))
-            {
-            case '\'':
-            case ',':
-              break strip_quotes;
-
-            case '\\':
-              if (yystr.charAt(++i) != '\\')
-                break strip_quotes;
-              /* Fall through.  */
-            default:
-              yyr.append (yystr.charAt (i));
-              break;
-
-            case '"':
-              return yyr.toString ();
-            }
-      }
-    else if (yystr.equals ("$end"))
-      return "end of input";
-
-    return yystr;
-  }
-]])[
 ]b4_parse_trace_if([[
   /*--------------------------------.
   | Print this symbol on YYOUTPUT.  |
@@ -534,7 +498,7 @@ m4_define([b4_define_state],[[
                               b4_locations_if([, Object yylocationp])[)
   {
     yycdebug (s + (yytype < yyntokens_ ? " token " : " nterm ")
-              + yytname_[yytype] + " ("]b4_locations_if([
+              + yysymbolName (yytype) + " ("]b4_locations_if([
               + yylocationp + ": "])[
               + (yyvaluep == null ? "(null)" : yyvaluep.toString ()) + ")");
   }]])[
@@ -924,7 +888,7 @@ b4_dollar_popdef[]dnl
                with internationalization.  */
             StringBuffer res =
               new StringBuffer ("syntax error, unexpected ");
-            res.append (yytnamerr_ (yytname_[tok]));
+            res.append (yysymbolName (tok));
             int yyn = yypact_[yystate];
             if (!yyPactValueIsDefault (yyn))
               {
@@ -949,7 +913,7 @@ b4_dollar_popdef[]dnl
                           && !yyTableValueIsError (yytable_[x + yyn]))
                         {
                           res.append (count++ == 0 ? ", expecting " : " or ");
-                          res.append (yytnamerr_ (yytname_[x]));
+                          res.append (yysymbolName (x));
                         }
                   }
               }
@@ -984,9 +948,63 @@ b4_dollar_popdef[]dnl
 
 ]b4_parser_tables_define[
 
+]m4_bmatch(b4_percent_define_get([[parse.error]]),
+           [simple\|verbose],
+[[  /* Return YYSTR after stripping away unnecessary quotes and
+     backslashes, so that it's suitable for yyerror.  The heuristic is
+     that double-quoting is unnecessary unless the string contains an
+     apostrophe, a comma, or backslash (other than backslash-backslash).
+     YYSTR is taken from yytname.  */
+  private static String yytnamerr_ (String yystr)
+  {
+    if (yystr.charAt (0) == '"')
+      {
+        StringBuffer yyr = new StringBuffer ();
+        strip_quotes: for (int i = 1; i < yystr.length (); i++)
+          switch (yystr.charAt (i))
+            {
+            case '\'':
+            case ',':
+              break strip_quotes;
+
+            case '\\':
+              if (yystr.charAt(++i) != '\\')
+                break strip_quotes;
+              /* Fall through.  */
+            default:
+              yyr.append (yystr.charAt (i));
+              break;
+
+            case '"':
+              return yyr.toString ();
+            }
+      }
+    else if (yystr.equals ("$end"))
+      return "end of input";
+
+    return yystr;
+  }
+
   /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
      First, the terminals, then, starting at \a yyntokens_, nonterminals.  */
   ]b4_typed_parser_table_define([String], [tname], [b4_tname])[
+
+  static String yysymbolName (int yysymbol)
+  {
+    return yytnamerr_ (yytname_[yysymbol]);
+  }
+]],
+        [custom\|detailed],
+[[/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static String yysymbolName (int yysymbol)
+{
+  String[] yy_sname =
+  {
+  ]b4_symbol_names[
+  };
+  return yy_sname[yysymbol];
+}]])[
 
 ]b4_parse_trace_if([[
   ]b4_integral_parser_table_define([rline], [b4_rline],

--- a/data/skeletons/lalr1.java
+++ b/data/skeletons/lalr1.java
@@ -866,80 +866,83 @@ b4_dollar_popdef[]dnl
     public int yytoken;]b4_locations_if([[
     public ]b4_location_type[ yylocation;]])[
     public static final int yyntokens = ]b4_parser_class[.yyntokens_;
-  };
 
-  /* Put in YYARG at most YYARGN of the expected tokens given the
-     current YYCTX, and return the number of tokens stored in YYARG.  If
-     YYARG is null, return the number of expected tokens (guaranteed to
-     be less than YYNTOKENS_).  */
-  static int
-  yyexpectedTokens (Context yyctx,
-                    int yyarg[], int yyoffset, int yyargn)
-  {
-    int yycount = yyoffset;
-    int yyn = yypact_[yyctx.yystack.stateAt (0)];
-    if (!yyPactValueIsDefault (yyn))
-      {
-        /* Start YYX at -YYN if negative to avoid negative
-           indexes in YYCHECK.  In other words, skip the first
-           -YYN actions for this state because they are default
-           actions.  */
-        int yyxbegin = yyn < 0 ? -yyn : 0;
-        /* Stay within bounds of both yycheck and yytname.  */
-        int yychecklim = yylast_ - yyn + 1;
-        int yyxend = yychecklim < yyntokens_ ? yychecklim : yyntokens_;
-        for (int x = yyxbegin; x < yyxend; ++x)
-          if (yycheck_[x + yyn] == x && x != yy_error_token_
-              && !yyTableValueIsError (yytable_[x + yyn]))
-            {
-              if (yyarg == null)
-                yycount += 1;
-              else if (yycount == yyargn)
-                return 0; // FIXME: this is incorrect.
-              else
-                yyarg[yycount++] = x;
-            }
-      }
-    return yycount - yyoffset;
-  }
+    /* Put in YYARG at most YYARGN of the expected tokens given the
+       current YYCTX, and return the number of tokens stored in YYARG.  If
+       YYARG is null, return the number of expected tokens (guaranteed to
+       be less than YYNTOKENS).  */
+    int yyexpectedTokens (int yyarg[], int yyoffset, int yyargn)
+    {
+      int yycount = yyoffset;
+      int yyn = yypact_[this.yystack.stateAt (0)];
+      if (!yyPactValueIsDefault (yyn))
+        {
+          /* Start YYX at -YYN if negative to avoid negative
+             indexes in YYCHECK.  In other words, skip the first
+             -YYN actions for this state because they are default
+             actions.  */
+          int yyxbegin = yyn < 0 ? -yyn : 0;
+          /* Stay within bounds of both yycheck and yytname.  */
+          int yychecklim = yylast_ - yyn + 1;
+          int yyxend = yychecklim < yyntokens ? yychecklim : yyntokens;
+          for (int x = yyxbegin; x < yyxend; ++x)
+            if (yycheck_[x + yyn] == x && x != yy_error_token_
+                && !yyTableValueIsError (yytable_[x + yyn]))
+              {
+                if (yyarg == null)
+                  yycount += 1;
+                else if (yycount == yyargn)
+                  return 0; // FIXME: this is incorrect.
+                else
+                  yyarg[yycount++] = x;
+              }
+        }
+      return yycount - yyoffset;
+    }
 
-  static int
-  yysyntaxErrorArguments (Context yyctx,
-                          int[] yyarg, int yyargn)
-  {
-    /* There are many possibilities here to consider:
-       - If this state is a consistent state with a default action,
-         then the only way this function was invoked is if the
-         default action is an error action.  In that case, don't
-         check for expected tokens because there are none.
-       - The only way there can be no lookahead present (in tok) is
-         if this state is a consistent state with a default action.
-         Thus, detecting the absence of a lookahead is sufficient to
-         determine that there is no unexpected or expected token to
-         report.  In that case, just report a simple "syntax error".
-       - Don't assume there isn't a lookahead just because this
-         state is a consistent state with a default action.  There
-         might have been a previous inconsistent state, consistent
-         state with a non-default action, or user semantic action
-         that manipulated yychar.  (However, yychar is currently out
-         of scope during semantic actions.)
-       - Of course, the expected token list depends on states to
-         have correct lookahead information, and it depends on the
-         parser not to perform extra reductions after fetching a
-         lookahead from the scanner and before detecting a syntax
-         error.  Thus, state merging (from LALR or IELR) and default
-         reductions corrupt the expected token list.  However, the
-         list is correct for canonical LR with one exception: it
-         will still contain any token that will not be accepted due
-         to an error action in a later state.
-    */
-    int yycount = 0;
-    if (yyctx.yytoken != yyempty_)
-      {
-        yyarg[yycount++] = yyctx.yytoken;
-        yycount += yyexpectedTokens (yyctx, yyarg, 1, yyargn);
-      }
-    return yycount;
+    /* The user-facing name of the symbol whose (internal) number is
+       YYSYMBOL.  No bounds checking.  */
+    static String yysymbolName (int yysymbol)
+    {
+      return ]b4_parser_class[.yysymbolName (yysymbol);
+    }
+
+    int yysyntaxErrorArguments (int[] yyarg, int yyargn)
+    {
+      /* There are many possibilities here to consider:
+         - If this state is a consistent state with a default action,
+           then the only way this function was invoked is if the
+           default action is an error action.  In that case, don't
+           check for expected tokens because there are none.
+         - The only way there can be no lookahead present (in tok) is
+           if this state is a consistent state with a default action.
+           Thus, detecting the absence of a lookahead is sufficient to
+           determine that there is no unexpected or expected token to
+           report.  In that case, just report a simple "syntax error".
+         - Don't assume there isn't a lookahead just because this
+           state is a consistent state with a default action.  There
+           might have been a previous inconsistent state, consistent
+           state with a non-default action, or user semantic action
+           that manipulated yychar.  (However, yychar is currently out
+           of scope during semantic actions.)
+         - Of course, the expected token list depends on states to
+           have correct lookahead information, and it depends on the
+           parser not to perform extra reductions after fetching a
+           lookahead from the scanner and before detecting a syntax
+           error.  Thus, state merging (from LALR or IELR) and default
+           reductions corrupt the expected token list.  However, the
+           list is correct for canonical LR with one exception: it
+           will still contain any token that will not be accepted due
+           to an error action in a later state.
+      */
+      int yycount = 0;
+      if (this.yytoken != yyempty_)
+        {
+          yyarg[yycount++] = this.yytoken;
+          yycount += this.yyexpectedTokens (yyarg, 1, yyargn);
+        }
+      return yycount;
+    }
   }
 
  /**
@@ -954,7 +957,7 @@ b4_dollar_popdef[]dnl
       {
         final int argmax = 5;
         int[] yyarg = new int[argmax];
-        int yycount = yysyntaxErrorArguments (yyctx, yyarg, argmax);
+        int yycount = yyctx.yysyntaxErrorArguments (yyarg, argmax);
         String[] yystr = new String[yycount];
         for (int yyi = 0; yyi < yycount; ++yyi)
           yystr[yyi] = yysymbolName (yyarg[yyi]);

--- a/data/skeletons/lalr1.java
+++ b/data/skeletons/lalr1.java
@@ -855,7 +855,7 @@ b4_dollar_popdef[]dnl
   }
 ]])[
 
-  public final class Context
+  public static final class Context
   {
     public YYStack yystack;
     public int yytoken;
@@ -1027,22 +1027,24 @@ b4_dollar_popdef[]dnl
      First, the terminals, then, starting at \a yyntokens_, nonterminals.  */
   ]b4_typed_parser_table_define([String], [tname], [b4_tname])[
 
+  /* The user-facing name of the symbol whose (internal) number is
+     YYSYMBOL.  No bounds checking.  */
   static String yysymbolName (int yysymbol)
   {
     return yytnamerr_ (yytname_[yysymbol]);
   }
 ]],
         [custom\|detailed],
-[[/* The user-facing name of the symbol whose (internal) number is
-   YYSYMBOL.  No bounds checking.  */
-static String yysymbolName (int yysymbol)
-{
-  String[] yy_sname =
+[[  /* The user-facing name of the symbol whose (internal) number is
+     YYSYMBOL.  No bounds checking.  */
+  static String yysymbolName (int yysymbol)
   {
-  ]b4_symbol_names[
-  };
-  return yy_sname[yysymbol];
-}]])[
+    String[] yy_sname =
+    {
+    ]b4_symbol_names[
+    };
+    return yy_sname[yysymbol];
+  }]])[
 
 ]b4_parse_trace_if([[
   ]b4_integral_parser_table_define([rline], [b4_rline],

--- a/examples/c/bistromathic/bistromathic.test
+++ b/examples/c/bistromathic/bistromathic.test
@@ -45,9 +45,9 @@ run 0 '0.16
 cat >input <<EOF
 *
 EOF
-run 0 "err: 1.1: syntax error expected end of file or - or ( or end of line or double precision number or function or variable before *"
+run 0 "err: 1.1: syntax error: expected end of file or - or ( or end of line or double precision number or function or variable before *"
 
 cat >input <<EOF
 1 + 2 * * 3
 EOF
-run 0 "err: 1.9: syntax error expected - or ( or double precision number or function or variable before *"
+run 0 "err: 1.9: syntax error: expected - or ( or double precision number or function or variable before *"

--- a/examples/c/bistromathic/parse.y
+++ b/examples/c/bistromathic/parse.y
@@ -200,8 +200,8 @@ yyreport_syntax_error (const yyparse_context_t *ctx)
   YY_LOCATION_PRINT (stderr, *yyparse_context_location (ctx));
   fprintf (stderr, ": syntax error");
   for (int i = 1; i < n; ++i)
-    fprintf (stderr, " %s %s",
-             i == 1 ? "expected" : "or", yysymbol_name (arg[i]));
+    fprintf (stderr, "%s %s",
+             i == 1 ? ": expected" : " or", yysymbol_name (arg[i]));
   if (n)
     fprintf (stderr, " before %s", yysymbol_name (arg[0]));
   fprintf (stderr, "\n");

--- a/examples/java/calc/Calc.test
+++ b/examples/java/calc/Calc.test
@@ -30,9 +30,9 @@ run 0 '7
 cat >input <<EOF
 1 + 2 * * 3
 EOF
-run 0 "err: 1.9-1.10: syntax error, unexpected '*', expecting number or '-' or '(' or '!'"
+run 0 "err: 1.9-1.10: syntax error: expected number or '-' or '(' or '!' before '*'"
 
 cat >input <<EOF
 12   222
 EOF
-run 0 "err: 1.6-1.9: syntax error, unexpected number"
+run 0 "err: 1.6-1.9: syntax error: expected end of line or '=' or '-' or '+' or '*' or '/' or '^' before number"

--- a/examples/java/calc/Calc.y
+++ b/examples/java/calc/Calc.y
@@ -110,13 +110,13 @@ class CalcLexer implements Calc.Lexer {
   {
     final int ARGMAX = 10;
     int[] arg = new int[ARGMAX];
-    int n = Calc.yysyntaxErrorArguments (ctx, arg, ARGMAX);
+    int n = ctx.yysyntaxErrorArguments (arg, ARGMAX);
     System.err.print (ctx.yylocation + ": syntax error");
     for (int i = 1; i < n; ++i)
       System.err.print ((i == 1 ? ": expected " : " or ")
-                        + Calc.yysymbolName (arg[i]));
+                        + ctx.yysymbolName (arg[i]));
     if (n != 0)
-      System.err.print (" before " + Calc.yysymbolName (arg[0]));
+      System.err.print (" before " + ctx.yysymbolName (arg[0]));
     System.err.println ("");
   }
 

--- a/examples/java/calc/Calc.y
+++ b/examples/java/calc/Calc.y
@@ -3,7 +3,7 @@
 %define api.parser.class {Calc}
 %define api.parser.public
 
-%define parse.error verbose
+%define parse.error detailed
 %define parse.trace
 
 %locations

--- a/src/output.c
+++ b/src/output.c
@@ -200,8 +200,8 @@ prepare_symbol_names (char const *muscle_name)
   set_quoting_flags (qo, QA_SPLIT_TRIGRAPHS);
   for (int i = 0; i < nsyms; i++)
     {
-      char *cp =
-        symbols[i]->tag[0] == '"' && !quote
+      char *cp
+        = symbols[i]->tag[0] == '"' && !quote
         ? xescape_trigraphs (symbols[i]->tag)
         : quotearg_alloc (symbols[i]->tag, -1, qo);
       /* Width of the next token, including the two quotes, the
@@ -219,10 +219,10 @@ prepare_symbol_names (char const *muscle_name)
       if (i)
         obstack_1grow (&format_obstack, ' ');
       if (!quote && symbols[i]->translatable)
-        obstack_sgrow (&format_obstack, "N_(");
+        obstack_sgrow (&format_obstack, "]b4_symbol_translate([");
       obstack_escape (&format_obstack, cp);
       if (!quote && symbols[i]->translatable)
-        obstack_1grow (&format_obstack, ')');
+        obstack_sgrow (&format_obstack, "])[");
       free (cp);
       obstack_1grow (&format_obstack, ',');
       j += width;

--- a/src/output.c
+++ b/src/output.c
@@ -194,6 +194,7 @@ prepare_symbol_names (char const *muscle_name)
 {
   /* We assume that the table will be output starting at column 2. */
   const bool quote = STREQ (muscle_name, "tname");
+  bool has_translations = false;
   int j = 2;
   struct quoting_options *qo = clone_quoting_options (0);
   set_quoting_style (qo, c_quoting_style);
@@ -219,7 +220,10 @@ prepare_symbol_names (char const *muscle_name)
       if (i)
         obstack_1grow (&format_obstack, ' ');
       if (!quote && symbols[i]->translatable)
-        obstack_sgrow (&format_obstack, "]b4_symbol_translate([");
+        {
+          has_translations = true;
+          obstack_sgrow (&format_obstack, "]b4_symbol_translate([");
+        }
       obstack_escape (&format_obstack, cp);
       if (!quote && symbols[i]->translatable)
         obstack_sgrow (&format_obstack, "])[");
@@ -232,6 +236,10 @@ prepare_symbol_names (char const *muscle_name)
 
   /* Finish table and store. */
   muscle_insert (muscle_name, obstack_finish0 (&format_obstack));
+
+  /* Announce whether translation support is needed.  */
+  if (!quote)
+    MUSCLE_INSERT_BOOL ("has_translations", has_translations);
 }
 
 

--- a/tests/calc.at
+++ b/tests/calc.at
@@ -1185,8 +1185,11 @@ m4_define([AT_CHECK_CALC_LALR1_JAVA],
 [AT_CHECK_CALC([%language "Java" $1], [$2])])
 
 AT_CHECK_CALC_LALR1_JAVA
+AT_CHECK_CALC_LALR1_JAVA([%define parse.error custom])
 AT_CHECK_CALC_LALR1_JAVA([%define parse.error detailed])
 AT_CHECK_CALC_LALR1_JAVA([%define parse.error verbose])
+AT_CHECK_CALC_LALR1_JAVA([%locations %define parse.error custom])
+AT_CHECK_CALC_LALR1_JAVA([%locations %define parse.error detailed])
 AT_CHECK_CALC_LALR1_JAVA([%locations %define parse.error verbose])
 AT_CHECK_CALC_LALR1_JAVA([%define parse.trace %define parse.error verbose])
 AT_CHECK_CALC_LALR1_JAVA([%define parse.trace %define parse.error verbose %locations %lex-param {InputStream is}])

--- a/tests/calc.at
+++ b/tests/calc.at
@@ -509,7 +509,6 @@ void location_print (FILE *o, Span s);
     const char *
     _ (const char *cp)
     {
-      /* Make sure only "end of input" is translated.  */
       if (strcmp (cp, "end of input") == 0)
         return "end of file";
       else if (strcmp (cp, "number") == 0)
@@ -649,10 +648,23 @@ m4_define([_AT_DATA_CALC_Y(java)],
 }
 
 %code {
-]AT_CALC_MAIN[
+  ]AT_CALC_MAIN[
+
+  ]AT_TOKEN_TRANSLATE_IF([[
+    static String _ (String s)
+    {
+      if (s.equals ("end of input"))
+        return "end of file";
+      else if (s.equals ("number"))
+        return "nombre";
+      else
+        return s;
+    }
+  ]])[
 }
 
 /* Bison Declarations */
+%token CALC_EOF 0 ]AT_TOKEN_TRANSLATE_IF([_("end of input")], ["end of input"])[
 %token <Integer> NUM "number"
 %type  <Integer> exp
 
@@ -1173,6 +1185,7 @@ m4_define([AT_CHECK_CALC_LALR1_JAVA],
 [AT_CHECK_CALC([%language "Java" $1], [$2])])
 
 AT_CHECK_CALC_LALR1_JAVA
+AT_CHECK_CALC_LALR1_JAVA([%define parse.error detailed])
 AT_CHECK_CALC_LALR1_JAVA([%define parse.error verbose])
 AT_CHECK_CALC_LALR1_JAVA([%locations %define parse.error verbose])
 AT_CHECK_CALC_LALR1_JAVA([%define parse.trace %define parse.error verbose])

--- a/tests/local.at
+++ b/tests/local.at
@@ -934,14 +934,14 @@ m4_define([AT_YYERROR_DEFINE(java)],
   public void yyreportSyntaxError (Calc.Context ctx)
   {
     int[] arg = new int[ctx.yyntokens];
-    int n = Calc.yysyntaxErrorArguments (ctx, arg, ctx.yyntokens);
+    int n = ctx.yysyntaxErrorArguments (arg, ctx.yyntokens);
     System.err.print (]AT_LOCATION_IF([[ctx.yylocation + ": "]]
-                      + )["syntax error on token @<:@" + Calc.yysymbolName(arg[0]) + "@:>@");
+                      + )["syntax error on token @<:@" + ctx.yysymbolName (arg[0]) + "@:>@");
     if (1 < n)
       {
         System.err.print (" (expected:");
         for (int i = 1; i < n; ++i)
-          System.err.print (" @<:@" + Calc.yysymbolName (arg[i]) + "@:>@");
+          System.err.print (" @<:@" + ctx.yysymbolName (arg[i]) + "@:>@");
         System.err.print (")");
       }
     System.err.println ("");

--- a/tests/local.at
+++ b/tests/local.at
@@ -908,6 +908,9 @@ class PositionReader extends BufferedReader {
 }]])
 
 
+# AT_YYERROR_DEFINE(java)
+# -----------------------
+# FIXME: We should not hard-code "Calc".
 m4_define([AT_YYERROR_DEFINE(java)],
 [AT_LOCATION_IF([[public void yyerror (Calc.Location l, String m)
   {]m4_bmatch(m4_defn([AT_PARSE_PARAMS]), [nerrs],[[
@@ -924,6 +927,24 @@ m4_define([AT_YYERROR_DEFINE(java)],
     ++global_nerrs;
     ++*nerrs;]])[
     System.err.println (m);
+  }
+]])[
+
+]AT_ERROR_CUSTOM_IF([[
+  public void yyreportSyntaxError (Calc.Context ctx)
+  {
+    int[] arg = new int[ctx.yyntokens];
+    int n = Calc.yysyntaxErrorArguments (ctx, arg, ctx.yyntokens);
+    System.err.print (]AT_LOCATION_IF([[ctx.yylocation + ": "]]
+                      + )["syntax error on token @<:@" + Calc.yysymbolName(arg[0]) + "@:>@");
+    if (1 < n)
+      {
+        System.err.print (" (expected:");
+        for (int i = 1; i < n; ++i)
+          System.err.print (" @<:@" + Calc.yysymbolName (arg[i]) + "@:>@");
+        System.err.print (")");
+      }
+    System.err.println ("");
   }
 ]])
 ])
@@ -961,6 +982,8 @@ m4_define([AT_MAIN_DEFINE(java)],
 
 m4_define([AT_LANG_FOR_EACH_STD(java)],
 [$1])
+
+
 
 ## --------------- ##
 ## Running Bison.  ##


### PR DESCRIPTION
This is my proposal to add support for parse.error custom|detailed to Java.  I'm no Java programmer, and I have absolutely no idea if this is the proper way to do it (and push parsers must be checked too). But at least it's a starting point from which to discuss.

To see it work, have a look at examples/java/calc:

``` Java
%define parse.error custom
...
%code {
  static String _ (String s)
  {
    return s;
  }
}
%%
class CalcLexer implements Calc.Lexer {
...
  public void yyreportSyntaxError (Calc.Context ctx)
  {
    final int ARGMAX = 10;
    int[] arg = new int[ARGMAX];
    int n = ctx.yysyntaxErrorArguments (arg, ARGMAX);
    System.err.print (ctx.yylocation + ": syntax error");
    for (int i = 1; i < n; ++i)
      System.err.print ((i == 1 ? ": expected " : " or ")
                        + ctx.yysymbolName (arg[i]));
    if (n != 0)
      System.err.print (" before " + ctx.yysymbolName (arg[0]));
    System.err.println ("");
  }
...
```