### PR TITLE
Deprecate yysyntax_error_arguments

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -4,6 +4,7 @@ it is today without the invaluable help of these people:
 Aaro Koskinen             aaro.koskinen@iki.fi
 Аскар Сафин               safinaskar@mail.ru
 Adam Sampson              ats@offog.org
+Adrian Vogelsgesang       avogelsgesang@tableau.com
 Ahcheong Lee              dkcjd2000@gmail.com
 Airy Andre                Airy.Andre@edf.fr
 Akim Demaille             akim@gnu.org

--- a/TODO
+++ b/TODO
@@ -2,12 +2,11 @@
 ** Documentation
 - yyexpected_tokens in all the languages.
 - remove yysyntax_error_arguments.
+- YYNOMEM
 
 ** Naming conventions
 yysyntax_error_arguments should be yy_syntax_error_arguments, since it's a
 private implementation detail.
-
-Give a name to magic constants such as -2 (YYNOMEM?).
 
 There's no good reason to use the "yy" prefix in parser::context, is there?
 See also the case of Java.  We should keep the prefix for private

--- a/TODO
+++ b/TODO
@@ -1,4 +1,53 @@
 * Bison 3.6
+** Documentation
+- yyexpected_tokens in all the languages.
+- remove yysyntax_error_arguments.
+
+** Naming conventions
+yysyntax_error_arguments should be yy_syntax_error_arguments, since it's a
+private implementation detail.
+
+Give a name to magic constants such as -2 (YYNOMEM?).
+
+There's no good reason to use the "yy" prefix in parser::context, is there?
+See also the case of Java.  We should keep the prefix for private
+implementation details, but maybe not for public APIs.
+
+** User token number, internal synbol number, external token number, etc.
+There is some confusion over these terms, which is even a problem for
+translators.  We need something clear, especially if we provide access to
+the symbol numbers (which would be useful for custom error messages).
+
+*** The documentation
+
+You can explicitly specify the numeric code for a token type...
+
+The token numbered as 0.
+
+Therefore each time the scanner returns an (external) token number,
+it must be mapped to the (internal) symbol number.
+
+
+*** The code
+uses "user token number" in most places.
+
+  if (sym->content->class != token_sym)
+    complain (&loc, complaint,
+              _("nonterminals cannot be given an explicit number"));
+  else if (*user_token_numberp != USER_NUMBER_UNDEFINED
+           && *user_token_numberp != user_token_number)
+    complain (&loc, complaint, _("redefining user token number of %s"),
+              sym->tag);
+  else if (user_token_number == INT_MAX)
+    complain (&loc, complaint, _("user token number of %s too large"),
+              sym->tag);
+
+** Symbol numbers
+Giving names to symbol numbers would be useful in custom error messages.  It
+would actually also make the following point gracefully handled (status of
+YYERRCODE, YYUNDEFTOK, etc.).  Possibly we could also define YYEMPTY (twice:
+as a token and as a symbol).  And YYEOF.
+
 ** Consistency
 YYUNDEFTOK is an internal symbol number, as YYTERROR.
 But YYERRCODE is an external token number.
@@ -21,24 +70,6 @@ examples/java/calc/Calc.java:998: warning: '_' used as an identifier
 I feel it's ugly to use the GNU style to declare functions in the doc.  It
 generates tons of white space in the page, and may contribute to bad page
 breaks.
-
-** Bad styling
-When the quoted line is shorter than expected, the styling is closed, so it
-"leaks" till the end of the diagnostics.
-
-    $ cat parser.yy
-    #line 1
-    // foo
-    %define parser_class_name {foo}
-    %language "C++"
-    %%
-    exp:
-    $ bison --color=debug /tmp/parser.yy
-    /tmp/parser.yy:2.1-31: <warning>avertissement:</warning> directive dépréciée: « %define parser_class_name {foo} », utilisez « %define api.parser.class {foo} » [<warning>-Wdeprecated</warning>]
-        2 | <warning>// foo
-          | <warning>^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~</warning>
-          | <fixit-insert>%define api.parser.class {foo}</fixit-insert>
-    /tmp/parser.yy: <warning>avertissement:</warning> des fix-its peuvent être appliqués. Exécutez à nouveau avec l'option « --update ». [<warning>-Wother</warning>]
 
 ** improve syntax errors (UTF-8, internationalization)
 Bison depends on the current locale.  For instance:
@@ -93,7 +124,9 @@ See also the item "$undefined" below.
 
 ** push parsers
 Consider deprecating impure push parsers.  They add a lot of complexity, for
-a bad feature.
+a bad feature.  On the other hand, that would make it much harder to sit
+push parsers on top of pull parser.  Which is currently not relevant, since
+push parsers are measurably slower.
 
 * Bison 3.7
 ** Unit rules / Injection rules (Akim Demaille)

--- a/data/skeletons/glr.c
+++ b/data/skeletons/glr.c
@@ -430,6 +430,8 @@ YYLTYPE yylloc;]])[
 int yynerrs;
 int yychar;])[
 
+enum { YYNOMEM = -2 };
+
 static const int YYEOF = 0;
 static const int YYEMPTY = -2;
 
@@ -2186,8 +2188,8 @@ yysyntax_error_arguments (const yyGLRStack* yystackp,
       int yyn;
       yyarg[yycount++] = yytoken;
       yyn = yyexpected_tokens (yystackp, yyarg ? yyarg + 1 : yyarg, yyargn - 1);
-      if (yyn == -2)
-        return -2;
+      if (yyn == YYNOMEM)
+        return YYNOMEM;
       else
         yycount += yyn;
     }
@@ -2222,7 +2224,7 @@ yyreportSyntaxError (yyGLRStack* yystackp]b4_user_formals[)
   /* Actual size of YYARG. */
   int yycount
     = yysyntax_error_arguments (yystackp, yyarg, YYARGS_MAX);
-  if (yycount == -2)
+  if (yycount == YYNOMEM)
     yyMemoryExhausted (yystackp);
 
   switch (yycount)

--- a/data/skeletons/glr.c
+++ b/data/skeletons/glr.c
@@ -2114,13 +2114,39 @@ yyexpected_tokens (const yyGLRStack* yystackp,
           }
     }
   return yycount;
+}]])[
+
+]b4_parse_error_bmatch(
+         [custom],
+[[/* User defined function to report a syntax error.  */
+typedef yyGLRStack yyparse_context_t;
+static int
+yyreport_syntax_error (const yyGLRStack* yystackp]b4_user_formals[);
+
+/* The token type of the lookahead of this context.  */
+static int
+yyparse_context_token (const yyGLRStack *yystackp) YY_ATTRIBUTE_UNUSED;
+
+static int
+yyparse_context_token (const yyGLRStack *yystackp)
+{
+  YYUSE (yystackp);
+  yySymbol yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
+  return yytoken;
 }
 
-static int
-yysyntax_error_arguments (const yyGLRStack* yystackp,
-                          int yyarg[], int yyargn) YY_ATTRIBUTE_UNUSED;
+]b4_locations_if([[/* The location of the lookahead of this context.  */
+static YYLTYPE *
+yyparse_context_location (const yyGLRStack *yystackp) YY_ATTRIBUTE_UNUSED;
 
-static int
+static YYLTYPE *
+yyparse_context_location (const yyGLRStack *yystackp)
+{
+  YYUSE (yystackp);
+  return &yylloc;
+}]])],
+         [detailed\|verbose],
+[[static int
 yysyntax_error_arguments (const yyGLRStack* yystackp,
                           int yyarg[], int yyargn)
 {
@@ -2168,36 +2194,6 @@ yysyntax_error_arguments (const yyGLRStack* yystackp,
   return yycount;
 }
 ]])[
-
-]b4_parse_error_case(
-         [custom],
-[[/* User defined function to report a syntax error.  */
-typedef yyGLRStack yyparse_context_t;
-static int
-yyreport_syntax_error (const yyGLRStack* yystackp]b4_user_formals[);
-
-/* The token type of the lookahead of this context.  */
-static int
-yyparse_context_token (const yyGLRStack *yystackp) YY_ATTRIBUTE_UNUSED;
-
-static int
-yyparse_context_token (const yyGLRStack *yystackp)
-{
-  YYUSE (yystackp);
-  yySymbol yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
-  return yytoken;
-}
-
-]b4_locations_if([[/* The location of the lookahead of this context.  */
-static YYLTYPE *
-yyparse_context_location (const yyGLRStack *yystackp) YY_ATTRIBUTE_UNUSED;
-
-static YYLTYPE *
-yyparse_context_location (const yyGLRStack *yystackp)
-{
-  YYUSE (yystackp);
-  return &yylloc;
-}]])])[
 
 
 static void

--- a/data/skeletons/glr.c
+++ b/data/skeletons/glr.c
@@ -2118,6 +2118,10 @@ yyexpected_tokens (const yyGLRStack* yystackp,
 
 static int
 yysyntax_error_arguments (const yyGLRStack* yystackp,
+                          int yyarg[], int yyargn) YY_ATTRIBUTE_UNUSED;
+
+static int
+yysyntax_error_arguments (const yyGLRStack* yystackp,
                           int yyarg[], int yyargn)
 {
   yySymbol yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
@@ -2172,7 +2176,19 @@ typedef yyGLRStack yyparse_context_t;
 static int
 yyreport_syntax_error (const yyGLRStack* yystackp]b4_user_formals[);
 
-]b4_locations_if([[/*  The location of this context.  */
+/* The token type of the lookahead of this context.  */
+static int
+yyparse_context_token (const yyGLRStack *yystackp) YY_ATTRIBUTE_UNUSED;
+
+static int
+yyparse_context_token (const yyGLRStack *yystackp)
+{
+  YYUSE (yystackp);
+  yySymbol yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
+  return yytoken;
+}
+
+]b4_locations_if([[/* The location of the lookahead of this context.  */
 static YYLTYPE *
 yyparse_context_location (const yyGLRStack *yystackp) YY_ATTRIBUTE_UNUSED;
 

--- a/data/skeletons/lalr1.cc
+++ b/data/skeletons/lalr1.cc
@@ -239,7 +239,8 @@ m4_define([b4_shared_declarations],
     class context
     {
     public:
-      context (const ]b4_parser_class[& yyparser, const symbol_type& yyla);]b4_locations_if([[
+      context (const ]b4_parser_class[& yyparser, const symbol_type& yyla);
+      int token () const { return yyla_.type_get (); }]b4_locations_if([[
       const location_type& location () const { return yyla_.location; }
 ]])[
       /// Put in YYARG at most YYARGN of the expected tokens, and return the

--- a/data/skeletons/lalr1.java
+++ b/data/skeletons/lalr1.java
@@ -933,46 +933,49 @@ b4_dollar_popdef[]dnl
     {
       return ]b4_parser_class[.yysymbolName (yysymbol);
     }
-
-    int yysyntaxErrorArguments (int[] yyarg, int yyargn)
-    {
-      /* There are many possibilities here to consider:
-         - If this state is a consistent state with a default action,
-           then the only way this function was invoked is if the
-           default action is an error action.  In that case, don't
-           check for expected tokens because there are none.
-         - The only way there can be no lookahead present (in tok) is
-           if this state is a consistent state with a default action.
-           Thus, detecting the absence of a lookahead is sufficient to
-           determine that there is no unexpected or expected token to
-           report.  In that case, just report a simple "syntax error".
-         - Don't assume there isn't a lookahead just because this
-           state is a consistent state with a default action.  There
-           might have been a previous inconsistent state, consistent
-           state with a non-default action, or user semantic action
-           that manipulated yychar.  (However, yychar is currently out
-           of scope during semantic actions.)
-         - Of course, the expected token list depends on states to
-           have correct lookahead information, and it depends on the
-           parser not to perform extra reductions after fetching a
-           lookahead from the scanner and before detecting a syntax
-           error.  Thus, state merging (from LALR or IELR) and default
-           reductions corrupt the expected token list.  However, the
-           list is correct for canonical LR with one exception: it
-           will still contain any token that will not be accepted due
-           to an error action in a later state.
-      */
-      int yycount = 0;
-      if (this.yytoken != yyempty_)
-        {
-          yyarg[yycount++] = this.yytoken;
-          yycount += this.yyexpectedTokens (yyarg, 1, yyargn);
-        }
-      return yycount;
-    }
   }
 
- /**
+]b4_parse_error_bmatch(
+[detailed\|verbose], [[
+  private int yysyntaxErrorArguments (Context yyctx, int[] yyarg, int yyargn)
+  {
+    /* There are many possibilities here to consider:
+       - If this state is a consistent state with a default action,
+         then the only way this function was invoked is if the
+         default action is an error action.  In that case, don't
+         check for expected tokens because there are none.
+       - The only way there can be no lookahead present (in tok) is
+         if this state is a consistent state with a default action.
+         Thus, detecting the absence of a lookahead is sufficient to
+         determine that there is no unexpected or expected token to
+         report.  In that case, just report a simple "syntax error".
+       - Don't assume there isn't a lookahead just because this
+         state is a consistent state with a default action.  There
+         might have been a previous inconsistent state, consistent
+         state with a non-default action, or user semantic action
+         that manipulated yychar.  (However, yychar is currently out
+         of scope during semantic actions.)
+       - Of course, the expected token list depends on states to
+         have correct lookahead information, and it depends on the
+         parser not to perform extra reductions after fetching a
+         lookahead from the scanner and before detecting a syntax
+         error.  Thus, state merging (from LALR or IELR) and default
+         reductions corrupt the expected token list.  However, the
+         list is correct for canonical LR with one exception: it
+         will still contain any token that will not be accepted due
+         to an error action in a later state.
+    */
+    int yycount = 0;
+    if (yyctx.getToken () != yyempty_)
+      {
+        yyarg[yycount++] = yyctx.getToken ();
+        yycount += yyctx.yyexpectedTokens (yyarg, 1, yyargn);
+      }
+    return yycount;
+  }
+]])[
+
+/**
    * Report a syntax error.
    */
   private void yyreportSyntaxError (Context yyctx)
@@ -984,7 +987,7 @@ b4_dollar_popdef[]dnl
       {
         final int argmax = 5;
         int[] yyarg = new int[argmax];
-        int yycount = yyctx.yysyntaxErrorArguments (yyarg, argmax);
+        int yycount = yysyntaxErrorArguments (yyctx, yyarg, argmax);
         String[] yystr = new String[yycount];
         for (int yyi = 0; yyi < yycount; ++yyi)
           yystr[yyi] = yysymbolName (yyarg[yyi]);

--- a/data/skeletons/lalr1.java
+++ b/data/skeletons/lalr1.java
@@ -867,19 +867,37 @@ b4_dollar_popdef[]dnl
       yytoken = token;]b4_locations_if([[
       yylocation = loc;]])[
     }
+
     private YYStack yystack;
+
+    public int getToken ()
+    {
+      return yytoken;
+    }
+
+    /**
+     * Value returned by getToken when there is no token.
+     */
+    public static final int EMPTY = ]b4_parser_class[.yyempty_;
+
     private int yytoken;]b4_locations_if([[
     public ]b4_location_type[ getLocation ()
     {
       return yylocation;
     }
+
     private ]b4_location_type[ yylocation;]])[
-    static final int yyntokens = ]b4_parser_class[.yyntokens_;
+    static final int NTOKENS = ]b4_parser_class[.yyntokens_;
 
     /* Put in YYARG at most YYARGN of the expected tokens given the
        current YYCTX, and return the number of tokens stored in YYARG.  If
        YYARG is null, return the number of expected tokens (guaranteed to
        be less than YYNTOKENS).  */
+    int yyexpectedTokens (int yyarg[], int yyargn)
+    {
+      return yyexpectedTokens (yyarg, 0, yyargn);
+    }
+
     int yyexpectedTokens (int yyarg[], int yyoffset, int yyargn)
     {
       int yycount = yyoffset;
@@ -893,7 +911,7 @@ b4_dollar_popdef[]dnl
           int yyxbegin = yyn < 0 ? -yyn : 0;
           /* Stay within bounds of both yycheck and yytname.  */
           int yychecklim = yylast_ - yyn + 1;
-          int yyxend = yychecklim < yyntokens ? yychecklim : yyntokens;
+          int yyxend = yychecklim < NTOKENS ? yychecklim : NTOKENS;
           for (int x = yyxbegin; x < yyxend; ++x)
             if (yycheck_[x + yyn] == x && x != yy_error_token_
                 && !yyTableValueIsError (yytable_[x + yyn]))

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -706,6 +706,8 @@ static const ]b4_int_type_for([b4_toknum])[ yytoknum[] =
 
 ]b4_parser_tables_define[
 
+enum { YYNOMEM = -2 };
+
 #define yyerrok         (yyerrstatus = 0)
 #define yyclearin       (yychar = YYEMPTY)
 #define YYEMPTY         (-2)
@@ -877,7 +879,7 @@ static char yypstate_allocated = 0;]])])[
    *YYTOP, and *YYCAPACITY to reflect the new capacity and memory
    location.  If *YYBOTTOM != YYBOTTOM_NO_FREE, then free the old stack
    using YYSTACK_FREE.  Return 0 if successful or if no reallocation is
-   required.  Return -2 if memory is exhausted.  */
+   required.  Return YYNOMEM if memory is exhausted.  */
 static int
 yy_lac_stack_realloc (YYPTRDIFF_T *yycapacity, YYPTRDIFF_T yyadd,
 #if ]b4_api_PREFIX[DEBUG
@@ -902,7 +904,7 @@ yy_lac_stack_realloc (YYPTRDIFF_T *yycapacity, YYPTRDIFF_T yyadd,
         {
           YYDPRINTF ((stderr, "%smax size exceeded%s", yydebug_prefix,
                       yydebug_suffix));
-          return -2;
+          return YYNOMEM;
         }
       if (YYMAXDEPTH < yyalloc)
         yyalloc = YYMAXDEPTH;
@@ -914,7 +916,7 @@ yy_lac_stack_realloc (YYPTRDIFF_T *yycapacity, YYPTRDIFF_T yyadd,
         {
           YYDPRINTF ((stderr, "%srealloc failed%s", yydebug_prefix,
                       yydebug_suffix));
-          return -2;
+          return YYNOMEM;
         }
       if (*yytop != yytop_empty)
         {
@@ -970,7 +972,7 @@ do {                                                                    \
       yy_lac_established = 1;                                           \
       switch (yy_lac (yyesa, &yyes, &yyes_capacity, yyssp, yytoken))    \
         {                                                               \
-        case -2:                                                        \
+        case YYNOMEM:                                                   \
           goto yyexhaustedlab;                                          \
         case 1:                                                         \
           goto yyerrlab;                                                \
@@ -1005,7 +1007,7 @@ do {                                                                     \
 
 /* Given the stack whose top is *YYSSP, return 0 iff YYTOKEN can
    eventually (after perhaps some reductions) be shifted, return 1 if
-   not, or return -2 if memory is exhausted.  As preconditions and
+   not, or return YYNOMEM if memory is exhausted.  As preconditions and
    postconditions: *YYES_CAPACITY is the allocated size of the array to
    which *YYES points, and either *YYES = YYESA or *YYES points to an
    array allocated with YYSTACK_ALLOC.  yy_lac may overwrite the
@@ -1105,7 +1107,7 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
                                       yyes, yyesa, &yyesp, yyes_prev))
               {
                 YYDPRINTF ((stderr, "\n"));
-                return -2;
+                return YYNOMEM;
               }
             YY_IGNORE_USELESS_CAST_BEGIN
             *++yyesp = YY_CAST (yy_state_t, yystate);
@@ -1132,9 +1134,9 @@ typedef struct
 /* Put in YYARG at most YYARGN of the expected tokens given the
    current YYCTX, and return the number of tokens stored in YYARG.  If
    YYARG is null, return the number of expected tokens (guaranteed to
-   be less than YYNTOKENS).  Return -2 on memory exhaustion.  Return 0
-   if there are more than YYARGN expected tokens, yet fill YYARG up to
-   YYARGN. */]b4_push_if([[
+   be less than YYNTOKENS).  Return YYNOMEM on memory exhaustion.
+   Return 0 if there are more than YYARGN expected tokens, yet fill
+   YYARG up to YYARGN. */]b4_push_if([[
 static int
 yypstate_expected_tokens (yypstate *yyps,
                           int yyarg[], int yyargn)]], [[
@@ -1151,8 +1153,8 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
       switch (yy_lac (]b4_push_if([[yyps->yyesa, &yyps->yyes, &yyps->yyes_capacity, yyps->yyssp, yyx]],
                                   [[yyctx->yyesa, yyctx->yyes, yyctx->yyes_capacity, yyctx->yyssp, yyx]])[))
         {
-        case -2:
-          return -2;
+        case YYNOMEM:
+          return YYNOMEM;
         case 1:
           continue;
         default:
@@ -1354,8 +1356,8 @@ yysyntax_error_arguments (const yyparse_context_t *yyctx,
       YYDPRINTF ((stderr, "Constructing syntax error message\n"));]])[
       yyarg[yycount++] = yyctx->yytoken;
       yyn = yyexpected_tokens (yyctx, yyarg ? yyarg + 1 : yyarg, yyargn - 1);
-      if (yyn == -2)
-        return -2;]b4_lac_if([[
+      if (yyn == YYNOMEM)
+        return YYNOMEM;]b4_lac_if([[
       else if (yyn == 0)
         YYDPRINTF ((stderr, "No expected tokens.\n"));]])[
       else
@@ -1371,9 +1373,9 @@ yysyntax_error_arguments (const yyparse_context_t *yyctx,
 
    Return 0 if *YYMSG was successfully written.  Return -1 if *YYMSG is
    not large enough to hold the message.  In that case, also set
-   *YYMSG_ALLOC to the required number of bytes.  Return -2 if the
+   *YYMSG_ALLOC to the required number of bytes.  Return YYNOMEM if the
    required number of bytes is too large to store]b4_lac_if([[ or if
-   yy_lac returned -2]])[.  */
+   yy_lac returned YYNOMEM]])[.  */
 static int
 yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
                 const yyparse_context_t *yyctx)
@@ -1389,8 +1391,8 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
 
   /* Actual size of YYARG. */
   int yycount = yysyntax_error_arguments (yyctx, yyarg, YYARGS_MAX);
-  if (yycount == -2)
-    return -2;
+  if (yycount == YYNOMEM)
+    return YYNOMEM;
 
   switch (yycount)
     {
@@ -1422,7 +1424,7 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
         if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
           yysize = yysize1;
         else
-          return -2;
+          return YYNOMEM;
       }
   }
 
@@ -1933,11 +1935,11 @@ yyerrlab:
               {
                 yymsg = yymsgbuf;
                 yymsg_alloc = sizeof yymsgbuf;
-                yysyntax_error_status = -2;
+                yysyntax_error_status = YYNOMEM;
               }
           }
         yyerror (]b4_yyerror_args[yymsgp);
-        if (yysyntax_error_status == -2)
+        if (yysyntax_error_status == YYNOMEM)
           goto yyexhaustedlab;
       }]])[
     }

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -1200,6 +1200,10 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
 
 static int
 yysyntax_error_arguments (const yyparse_context_t *yyctx,
+                          int yyarg[], int yyargn) YY_ATTRIBUTE_UNUSED;
+
+static int
+yysyntax_error_arguments (const yyparse_context_t *yyctx,
                           int yyarg[], int yyargn)
 {
   /* Actual size of YYARG. */
@@ -1251,7 +1255,17 @@ yysyntax_error_arguments (const yyparse_context_t *yyctx,
 
 ]b4_parse_error_case(
          [custom],
-[b4_locations_if([[/*  The location of this context.  */
+[[/* The token type of the lookahead of this context.  */
+static int
+yyparse_context_token (const yyparse_context_t *yyctx) YY_ATTRIBUTE_UNUSED;
+
+static int
+yyparse_context_token (const yyparse_context_t *yyctx)
+{
+  return yyctx->yytoken;
+}
+
+]b4_locations_if([[/* The location of the lookahead of this context.  */
 static YYLTYPE *
 yyparse_context_location (const yyparse_context_t *yyctx) YY_ATTRIBUTE_UNUSED;
 

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -1197,63 +1197,9 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
 {
   return yypstate_expected_tokens (yyctx->yyps, yyarg, yyargn);
 }]])[
-
-static int
-yysyntax_error_arguments (const yyparse_context_t *yyctx,
-                          int yyarg[], int yyargn) YY_ATTRIBUTE_UNUSED;
-
-static int
-yysyntax_error_arguments (const yyparse_context_t *yyctx,
-                          int yyarg[], int yyargn)
-{
-  /* Actual size of YYARG. */
-  int yycount = 0;
-  /* There are many possibilities here to consider:
-     - If this state is a consistent state with a default action, then
-       the only way this function was invoked is if the default action
-       is an error action.  In that case, don't check for expected
-       tokens because there are none.
-     - The only way there can be no lookahead present (in yychar) is if
-       this state is a consistent state with a default action.  Thus,
-       detecting the absence of a lookahead is sufficient to determine
-       that there is no unexpected or expected token to report.  In that
-       case, just report a simple "syntax error".
-     - Don't assume there isn't a lookahead just because this state is a
-       consistent state with a default action.  There might have been a
-       previous inconsistent state, consistent state with a non-default
-       action, or user semantic action that manipulated yychar.]b4_lac_if([[
-       In the first two cases, it might appear that the current syntax
-       error should have been detected in the previous state when yy_lac
-       was invoked.  However, at that time, there might have been a
-       different syntax error that discarded a different initial context
-       during error recovery, leaving behind the current lookahead.]], [[
-     - Of course, the expected token list depends on states to have
-       correct lookahead information, and it depends on the parser not
-       to perform extra reductions after fetching a lookahead from the
-       scanner and before detecting a syntax error.  Thus, state merging
-       (from LALR or IELR) and default reductions corrupt the expected
-       token list.  However, the list is correct for canonical LR with
-       one exception: it will still contain any token that will not be
-       accepted due to an error action in a later state.]])[
-  */
-  if (yyctx->yytoken != YYEMPTY)
-    {
-      int yyn;]b4_lac_if([[
-      YYDPRINTF ((stderr, "Constructing syntax error message\n"));]])[
-      yyarg[yycount++] = yyctx->yytoken;
-      yyn = yyexpected_tokens (yyctx, yyarg ? yyarg + 1 : yyarg, yyargn - 1);
-      if (yyn == -2)
-        return -2;]b4_lac_if([[
-      else if (yyn == 0)
-        YYDPRINTF ((stderr, "No expected tokens.\n"));]])[
-      else
-        yycount += yyn;
-    }
-  return yycount;
-}
 ]])[
 
-]b4_parse_error_case(
+]b4_parse_error_bmatch(
          [custom],
 [[/* The token type of the lookahead of this context.  */
 static int
@@ -1278,8 +1224,7 @@ yyparse_context_location (const yyparse_context_t *yyctx)
 /* User defined function to report a syntax error.  */
 static int
 yyreport_syntax_error (const yyparse_context_t *yyctx]b4_user_formals[);]],
-         [simple],
-[[]],
+         [detailed\|verbose],
 [[#ifndef yystrlen
 # if defined __GLIBC__ && defined _STRING_H
 #  define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
@@ -1368,6 +1313,56 @@ yytnamerr (char *yyres, const char *yystr)
 }
 #endif
 ]])[
+
+static int
+yysyntax_error_arguments (const yyparse_context_t *yyctx,
+                          int yyarg[], int yyargn)
+{
+  /* Actual size of YYARG. */
+  int yycount = 0;
+  /* There are many possibilities here to consider:
+     - If this state is a consistent state with a default action, then
+       the only way this function was invoked is if the default action
+       is an error action.  In that case, don't check for expected
+       tokens because there are none.
+     - The only way there can be no lookahead present (in yychar) is if
+       this state is a consistent state with a default action.  Thus,
+       detecting the absence of a lookahead is sufficient to determine
+       that there is no unexpected or expected token to report.  In that
+       case, just report a simple "syntax error".
+     - Don't assume there isn't a lookahead just because this state is a
+       consistent state with a default action.  There might have been a
+       previous inconsistent state, consistent state with a non-default
+       action, or user semantic action that manipulated yychar.]b4_lac_if([[
+       In the first two cases, it might appear that the current syntax
+       error should have been detected in the previous state when yy_lac
+       was invoked.  However, at that time, there might have been a
+       different syntax error that discarded a different initial context
+       during error recovery, leaving behind the current lookahead.]], [[
+     - Of course, the expected token list depends on states to have
+       correct lookahead information, and it depends on the parser not
+       to perform extra reductions after fetching a lookahead from the
+       scanner and before detecting a syntax error.  Thus, state merging
+       (from LALR or IELR) and default reductions corrupt the expected
+       token list.  However, the list is correct for canonical LR with
+       one exception: it will still contain any token that will not be
+       accepted due to an error action in a later state.]])[
+  */
+  if (yyctx->yytoken != YYEMPTY)
+    {
+      int yyn;]b4_lac_if([[
+      YYDPRINTF ((stderr, "Constructing syntax error message\n"));]])[
+      yyarg[yycount++] = yyctx->yytoken;
+      yyn = yyexpected_tokens (yyctx, yyarg ? yyarg + 1 : yyarg, yyargn - 1);
+      if (yyn == -2)
+        return -2;]b4_lac_if([[
+      else if (yyn == 0)
+        YYDPRINTF ((stderr, "No expected tokens.\n"));]])[
+      else
+        yycount += yyn;
+    }
+  return yycount;
+}
 
 /* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
    about the unexpected token YYTOKEN for the state stack whose top is

--- a/examples/c/bistromathic/parse.y
+++ b/examples/c/bistromathic/parse.y
@@ -284,23 +284,26 @@ yylex (const char **line, YYSTYPE *yylval, YYLTYPE *yylloc)
 int
 yyreport_syntax_error (const yyparse_context_t *ctx)
 {
-  enum { ARGMAX = 10 };
   int res = 0;
-  int arg[ARGMAX];
-  int n = yysyntax_error_arguments (ctx, arg, ARGMAX);
-  if (n < 0)
-    // Forward errors to yyparse.
-    res = n;
   YY_LOCATION_PRINT (stderr, *yyparse_context_location (ctx));
   fprintf (stderr, ": syntax error");
-  if (n >= 0)
-    {
-      for (int i = 1; i < n; ++i)
+  {
+    enum { TOKENMAX = 10 };
+    int expected[TOKENMAX];
+    int n = yyexpected_tokens (ctx, expected, TOKENMAX);
+    if (n < 0)
+      // Forward errors to yyparse.
+      res = n;
+    else
+      for (int i = 0; i < n; ++i)
         fprintf (stderr, "%s %s",
-                 i == 1 ? ": expected" : " or", yysymbol_name (arg[i]));
-      if (n)
-        fprintf (stderr, " before %s", yysymbol_name (arg[0]));
-    }
+                 i == 0 ? ": expected" : " or", yysymbol_name (expected[i]));
+  }
+  {
+    int lookahead = yyparse_context_token (ctx);
+    if (lookahead != YYEMPTY)
+      fprintf (stderr, " before %s", yysymbol_name (lookahead));
+  }
   fprintf (stderr, "\n");
   return res;
 }

--- a/examples/java/calc/Calc.y
+++ b/examples/java/calc/Calc.y
@@ -108,15 +108,20 @@ class CalcLexer implements Calc.Lexer {
 
   public void yyreportSyntaxError (Calc.Context ctx)
   {
-    final int ARGMAX = 10;
-    int[] arg = new int[ARGMAX];
-    int n = ctx.yysyntaxErrorArguments (arg, ARGMAX);
     System.err.print (ctx.getLocation () + ": syntax error");
-    for (int i = 1; i < n; ++i)
-      System.err.print ((i == 1 ? ": expected " : " or ")
-                        + ctx.yysymbolName (arg[i]));
-    if (n != 0)
-      System.err.print (" before " + ctx.yysymbolName (arg[0]));
+    {
+      final int TOKENMAX = 10;
+      int[] arg = new int[TOKENMAX];
+      int n = ctx.yyexpectedTokens (arg, TOKENMAX);
+      for (int i = 0; i < n; ++i)
+        System.err.print ((i == 0 ? ": expected " : " or ")
+                          + ctx.yysymbolName (arg[i]));
+    }
+    {
+      int lookahead = ctx.getToken ();
+      if (lookahead != ctx.EMPTY)
+        System.err.print (" before " + ctx.yysymbolName (lookahead));
+    }
     System.err.println ("");
   }
 

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -783,6 +783,8 @@ static const yytype_int8 yyr2[] =
 };
 
 
+enum { YYNOMEM = -2 };
+
 #define yyerrok         (yyerrstatus = 0)
 #define yyclearin       (yychar = YYEMPTY)
 #define YYEMPTY         (-2)
@@ -1237,7 +1239,7 @@ int yydebug;
    *YYTOP, and *YYCAPACITY to reflect the new capacity and memory
    location.  If *YYBOTTOM != YYBOTTOM_NO_FREE, then free the old stack
    using YYSTACK_FREE.  Return 0 if successful or if no reallocation is
-   required.  Return -2 if memory is exhausted.  */
+   required.  Return YYNOMEM if memory is exhausted.  */
 static int
 yy_lac_stack_realloc (YYPTRDIFF_T *yycapacity, YYPTRDIFF_T yyadd,
 #if GRAM_DEBUG
@@ -1262,7 +1264,7 @@ yy_lac_stack_realloc (YYPTRDIFF_T *yycapacity, YYPTRDIFF_T yyadd,
         {
           YYDPRINTF ((stderr, "%smax size exceeded%s", yydebug_prefix,
                       yydebug_suffix));
-          return -2;
+          return YYNOMEM;
         }
       if (YYMAXDEPTH < yyalloc)
         yyalloc = YYMAXDEPTH;
@@ -1274,7 +1276,7 @@ yy_lac_stack_realloc (YYPTRDIFF_T *yycapacity, YYPTRDIFF_T yyadd,
         {
           YYDPRINTF ((stderr, "%srealloc failed%s", yydebug_prefix,
                       yydebug_suffix));
-          return -2;
+          return YYNOMEM;
         }
       if (*yytop != yytop_empty)
         {
@@ -1325,7 +1327,7 @@ do {                                                                    \
       yy_lac_established = 1;                                           \
       switch (yy_lac (yyesa, &yyes, &yyes_capacity, yyssp, yytoken))    \
         {                                                               \
-        case -2:                                                        \
+        case YYNOMEM:                                                   \
           goto yyexhaustedlab;                                          \
         case 1:                                                         \
           goto yyerrlab;                                                \
@@ -1360,7 +1362,7 @@ do {                                                                     \
 
 /* Given the stack whose top is *YYSSP, return 0 iff YYTOKEN can
    eventually (after perhaps some reductions) be shifted, return 1 if
-   not, or return -2 if memory is exhausted.  As preconditions and
+   not, or return YYNOMEM if memory is exhausted.  As preconditions and
    postconditions: *YYES_CAPACITY is the allocated size of the array to
    which *YYES points, and either *YYES = YYESA or *YYES points to an
    array allocated with YYSTACK_ALLOC.  yy_lac may overwrite the
@@ -1460,7 +1462,7 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
                                       yyes, yyesa, &yyesp, yyes_prev))
               {
                 YYDPRINTF ((stderr, "\n"));
-                return -2;
+                return YYNOMEM;
               }
             YY_IGNORE_USELESS_CAST_BEGIN
             *++yyesp = YY_CAST (yy_state_t, yystate);
@@ -1485,9 +1487,9 @@ typedef struct
 /* Put in YYARG at most YYARGN of the expected tokens given the
    current YYCTX, and return the number of tokens stored in YYARG.  If
    YYARG is null, return the number of expected tokens (guaranteed to
-   be less than YYNTOKENS).  Return -2 on memory exhaustion.  Return 0
-   if there are more than YYARGN expected tokens, yet fill YYARG up to
-   YYARGN. */
+   be less than YYNTOKENS).  Return YYNOMEM on memory exhaustion.
+   Return 0 if there are more than YYARGN expected tokens, yet fill
+   YYARG up to YYARGN. */
 static int
 yyexpected_tokens (const yyparse_context_t *yyctx,
                    int yyarg[], int yyargn)
@@ -1500,8 +1502,8 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
     if (yyx != YYTERROR && yyx != YYUNDEFTOK)
       switch (yy_lac (yyctx->yyesa, yyctx->yyes, yyctx->yyes_capacity, yyctx->yyssp, yyx))
         {
-        case -2:
-          return -2;
+        case YYNOMEM:
+          return YYNOMEM;
         case 1:
           continue;
         default:

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -1237,7 +1237,7 @@ int yydebug;
    *YYTOP, and *YYCAPACITY to reflect the new capacity and memory
    location.  If *YYBOTTOM != YYBOTTOM_NO_FREE, then free the old stack
    using YYSTACK_FREE.  Return 0 if successful or if no reallocation is
-   required.  Return 1 if memory is exhausted.  */
+   required.  Return -2 if memory is exhausted.  */
 static int
 yy_lac_stack_realloc (YYPTRDIFF_T *yycapacity, YYPTRDIFF_T yyadd,
 #if GRAM_DEBUG
@@ -1262,7 +1262,7 @@ yy_lac_stack_realloc (YYPTRDIFF_T *yycapacity, YYPTRDIFF_T yyadd,
         {
           YYDPRINTF ((stderr, "%smax size exceeded%s", yydebug_prefix,
                       yydebug_suffix));
-          return 1;
+          return -2;
         }
       if (YYMAXDEPTH < yyalloc)
         yyalloc = YYMAXDEPTH;
@@ -1274,7 +1274,7 @@ yy_lac_stack_realloc (YYPTRDIFF_T *yycapacity, YYPTRDIFF_T yyadd,
         {
           YYDPRINTF ((stderr, "%srealloc failed%s", yydebug_prefix,
                       yydebug_suffix));
-          return 1;
+          return -2;
         }
       if (*yytop != yytop_empty)
         {
@@ -1325,7 +1325,7 @@ do {                                                                    \
       yy_lac_established = 1;                                           \
       switch (yy_lac (yyesa, &yyes, &yyes_capacity, yyssp, yytoken))    \
         {                                                               \
-        case 2:                                                         \
+        case -2:                                                        \
           goto yyexhaustedlab;                                          \
         case 1:                                                         \
           goto yyerrlab;                                                \
@@ -1360,7 +1360,7 @@ do {                                                                     \
 
 /* Given the stack whose top is *YYSSP, return 0 iff YYTOKEN can
    eventually (after perhaps some reductions) be shifted, return 1 if
-   not, or return 2 if memory is exhausted.  As preconditions and
+   not, or return -2 if memory is exhausted.  As preconditions and
    postconditions: *YYES_CAPACITY is the allocated size of the array to
    which *YYES points, and either *YYES = YYESA or *YYES points to an
    array allocated with YYSTACK_ALLOC.  yy_lac may overwrite the
@@ -1460,7 +1460,7 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
                                       yyes, yyesa, &yyesp, yyes_prev))
               {
                 YYDPRINTF ((stderr, "\n"));
-                return 2;
+                return -2;
               }
             YY_IGNORE_USELESS_CAST_BEGIN
             *++yyesp = YY_CAST (yy_state_t, yystate);
@@ -1485,7 +1485,9 @@ typedef struct
 /* Put in YYARG at most YYARGN of the expected tokens given the
    current YYCTX, and return the number of tokens stored in YYARG.  If
    YYARG is null, return the number of expected tokens (guaranteed to
-   be less than YYNTOKENS).  */
+   be less than YYNTOKENS).  Return -2 on memory exhaustion.  Return 0
+   if there are more than YYARGN expected tokens, yet fill YYARG up to
+   YYARGN. */
 static int
 yyexpected_tokens (const yyparse_context_t *yyctx,
                    int yyarg[], int yyargn)
@@ -1498,7 +1500,7 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
     if (yyx != YYTERROR && yyx != YYUNDEFTOK)
       switch (yy_lac (yyctx->yyesa, yyctx->yyes, yyctx->yyes_capacity, yyctx->yyssp, yyx))
         {
-        case 2:
+        case -2:
           return -2;
         case 1:
           continue;
@@ -1514,6 +1516,10 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
 }
 
 
+
+static int
+yysyntax_error_arguments (const yyparse_context_t *yyctx,
+                          int yyarg[], int yyargn) YY_ATTRIBUTE_UNUSED;
 
 static int
 yysyntax_error_arguments (const yyparse_context_t *yyctx,
@@ -1558,7 +1564,17 @@ yysyntax_error_arguments (const yyparse_context_t *yyctx,
 }
 
 
-/*  The location of this context.  */
+/* The token type of the lookahead of this context.  */
+static int
+yyparse_context_token (const yyparse_context_t *yyctx) YY_ATTRIBUTE_UNUSED;
+
+static int
+yyparse_context_token (const yyparse_context_t *yyctx)
+{
+  return yyctx->yytoken;
+}
+
+/* The location of the lookahead of this context.  */
 static YYLTYPE *
 yyparse_context_location (const yyparse_context_t *yyctx) YY_ATTRIBUTE_UNUSED;
 
@@ -2714,18 +2730,26 @@ yyreturn:
 int
 yyreport_syntax_error (const yyparse_context_t *ctx)
 {
-  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
+  int res = 0;
   /* Arguments of format: reported tokens (one for the "unexpected",
      one per "expected"). */
-  int arg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  int n = yysyntax_error_arguments (ctx, arg, YYERROR_VERBOSE_ARGS_MAXIMUM);
-  if (n == -2)
-    return 2;
-  const char *argv[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  for (int i = 0; i < n; ++i)
-    argv[i] = yysymbol_name (arg[i]);
-  syntax_error (*yyparse_context_location (ctx), n, argv);
-  return 0;
+  enum { ARGS_MAX = 5 };
+  const char *argv[ARGS_MAX];
+  int argc = 0;
+  int unexpected = yyparse_context_token (ctx);
+  if (unexpected != YYEMPTY)
+    {
+      argv[argc++] = yysymbol_name (unexpected);
+      int expected[ARGS_MAX - 1];
+      int nexpected = yyexpected_tokens (ctx, expected, ARGS_MAX - 1);
+      if (nexpected < 0)
+        res = nexpected;
+      else
+        for (int i = 0; i < nexpected; ++i)
+          argv[argc++] = yysymbol_name (expected[i]);
+    }
+  syntax_error (*yyparse_context_location (ctx), argc, argv);
+  return res;
 }
 
 

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -1517,52 +1517,6 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
 
 
 
-static int
-yysyntax_error_arguments (const yyparse_context_t *yyctx,
-                          int yyarg[], int yyargn) YY_ATTRIBUTE_UNUSED;
-
-static int
-yysyntax_error_arguments (const yyparse_context_t *yyctx,
-                          int yyarg[], int yyargn)
-{
-  /* Actual size of YYARG. */
-  int yycount = 0;
-  /* There are many possibilities here to consider:
-     - If this state is a consistent state with a default action, then
-       the only way this function was invoked is if the default action
-       is an error action.  In that case, don't check for expected
-       tokens because there are none.
-     - The only way there can be no lookahead present (in yychar) is if
-       this state is a consistent state with a default action.  Thus,
-       detecting the absence of a lookahead is sufficient to determine
-       that there is no unexpected or expected token to report.  In that
-       case, just report a simple "syntax error".
-     - Don't assume there isn't a lookahead just because this state is a
-       consistent state with a default action.  There might have been a
-       previous inconsistent state, consistent state with a non-default
-       action, or user semantic action that manipulated yychar.
-       In the first two cases, it might appear that the current syntax
-       error should have been detected in the previous state when yy_lac
-       was invoked.  However, at that time, there might have been a
-       different syntax error that discarded a different initial context
-       during error recovery, leaving behind the current lookahead.
-  */
-  if (yyctx->yytoken != YYEMPTY)
-    {
-      int yyn;
-      YYDPRINTF ((stderr, "Constructing syntax error message\n"));
-      yyarg[yycount++] = yyctx->yytoken;
-      yyn = yyexpected_tokens (yyctx, yyarg ? yyarg + 1 : yyarg, yyargn - 1);
-      if (yyn == -2)
-        return -2;
-      else if (yyn == 0)
-        YYDPRINTF ((stderr, "No expected tokens.\n"));
-      else
-        yycount += yyn;
-    }
-  return yycount;
-}
-
 
 /* The token type of the lookahead of this context.  */
 static int

--- a/src/parse-gram.y
+++ b/src/parse-gram.y
@@ -801,18 +801,26 @@ epilogue.opt:
 int
 yyreport_syntax_error (const yyparse_context_t *ctx)
 {
-  enum { ARGS_MAX = 5 };
+  int res = 0;
   /* Arguments of format: reported tokens (one for the "unexpected",
      one per "expected"). */
-  int arg[ARGS_MAX];
-  int n = yysyntax_error_arguments (ctx, arg, ARGS_MAX);
-  if (n < 0)
-    return n;
+  enum { ARGS_MAX = 5 };
   const char *argv[ARGS_MAX];
-  for (int i = 0; i < n; ++i)
-    argv[i] = yysymbol_name (arg[i]);
-  syntax_error (*yyparse_context_location (ctx), n, argv);
-  return 0;
+  int argc = 0;
+  int unexpected = yyparse_context_token (ctx);
+  if (unexpected != YYEMPTY)
+    {
+      argv[argc++] = yysymbol_name (unexpected);
+      int expected[ARGS_MAX - 1];
+      int nexpected = yyexpected_tokens (ctx, expected, ARGS_MAX - 1);
+      if (nexpected < 0)
+        res = nexpected;
+      else
+        for (int i = 0; i < nexpected; ++i)
+          argv[argc++] = yysymbol_name (expected[i]);
+    }
+  syntax_error (*yyparse_context_location (ctx), argc, argv);
+  return res;
 }
 
 

--- a/tests/local.at
+++ b/tests/local.at
@@ -964,8 +964,8 @@ m4_define([AT_YYERROR_DEFINE(java)],
 ]AT_ERROR_CUSTOM_IF([[
   public void yyreportSyntaxError (Calc.Context ctx)
   {
-    int[] arg = new int[ctx.yyntokens];
-    int n = ctx.yysyntaxErrorArguments (arg, ctx.yyntokens);
+    int[] arg = new int[ctx.NTOKENS];
+    int n = ctx.yysyntaxErrorArguments (arg, ctx.NTOKENS);
     System.err.print (]AT_LOCATION_IF([[ctx.getLocation () + ": "]]
                       + )["syntax error on token @<:@" + ctx.yysymbolName (arg[0]) + "@:>@");
     if (1 < n)

--- a/tests/local.at
+++ b/tests/local.at
@@ -741,33 +741,36 @@ void
 }]AT_ERROR_CUSTOM_IF([[
 void
 ]AT_NAMESPACE[::parser::yyreport_syntax_error (const context& ctx) const
-{
-  /* Arguments of yyformat: reported tokens (one for the "unexpected",
-     one per "expected"). */
-  int arg[yyntokens_];
-  int n = ctx.yysyntax_error_arguments (arg, yyntokens_);]AT_PARAM_IF([m4_bpatsubst(m4_defn([AT_PARSE_PARAMS]),
+{]AT_PARAM_IF([m4_bpatsubst(m4_defn([AT_PARSE_PARAMS]),
               [[^,]+[^A-Za-z_0-9]\([A-Za-z_][A-Za-z_0-9]*\),* *], [
   YYUSE (\1);])])[]m4_bmatch(m4_defn([AT_PARSE_PARAMS]), [nerrs],[[
   ++global_nerrs;
-  ++*nerrs;]])[
-  if (n)
-  {]AT_LOCATION_IF([[
-    std::cerr << ctx.location () << ": ";]])[
-    std::cerr << "syntax error on token [" << yysymbol_name (arg[0]) << ']';
-    if (1 < n)
+  ++*nerrs;]])[]AT_LOCATION_IF([[
+  std::cerr << ctx.location () << ": ";]])[
+  std::cerr << "syntax error";
+  {
+    int la = ctx.token ();
+    if (la != empty_symbol)
+      fprintf (stderr, " on token [%s]", yysymbol_name (la));
+  }
+  {
+    enum { TOKENMAX = 10 };
+    int expected[TOKENMAX];
+    int n = ctx.yyexpected_tokens (expected, TOKENMAX);
+    if (0 < n)
       {
         std::cerr << " (expected:";
-        for (int i = 1; i < n; ++i)
-          std::cerr << " [" << yysymbol_name (arg[i]) << ']';
+        for (int i = 0; i < n; ++i)
+          std::cerr << " [" << yysymbol_name (expected[i]) << ']';
         std::cerr << ')';
       }
-    std::cerr << '\n';
   }
+  std::cerr << '\n';
 }]])])
 
 
 # AT_YYLEX_DEFINE(c++)([INPUT], [ACTION])
-# -----------------------------------------
+# ---------------------------------------
 # Same as in C.
 m4_copy([AT_YYLEX_DEFINE(c)], [AT_YYLEX_DEFINE(c++)])
 

--- a/tests/local.at
+++ b/tests/local.at
@@ -624,31 +624,36 @@ location_print (FILE *yyo, ]AT_YYLTYPE[ const * const yylocp)
 int
 yyreport_syntax_error (const yyparse_context_t *ctx]AT_PARAM_IF([, AT_PARSE_PARAMS])[)
 {
-  /* Arguments of yyformat: reported tokens (one for the "unexpected",
-     one per "expected"). */
-  int arg[YYNTOKENS];
-  int n = yysyntax_error_arguments (ctx, arg, YYNTOKENS);]AT_PARAM_IF([m4_bpatsubst(m4_defn([AT_PARSE_PARAMS]),
+  int res = 0;]AT_PARAM_IF([m4_bpatsubst(m4_defn([AT_PARSE_PARAMS]),
               [[^,]+[^A-Za-z_0-9]\([A-Za-z_][A-Za-z_0-9]*\),* *], [
   YYUSE (\1);])])[]m4_bmatch(m4_defn([AT_PARSE_PARAMS]), [nerrs],[[
   ++global_nerrs;
-  ++*nerrs;]])[
-  if (n < 0)
-    return n;
-  if (n)
-  {]AT_LOCATION_IF([[
-    LOCATION_PRINT (stderr, *yyparse_context_location (ctx));
-    fprintf (stderr, ": ");]])[
-    fprintf (stderr, "syntax error on token [%s]", yysymbol_name (arg[0]));
-    if (1 < n)
+  ++*nerrs;]])[]AT_LOCATION_IF([[
+  LOCATION_PRINT (stderr, *yyparse_context_location (ctx));
+  fprintf (stderr, ": ");]])[
+  fprintf (stderr, "syntax error");
+  {
+    int la = yyparse_context_token (ctx);
+    if (la != YYEMPTY)
+      fprintf (stderr, " on token [%s]", yysymbol_name (la));
+  }
+  {
+    enum { TOKENMAX = 10 };
+    int expected[TOKENMAX];
+    int n = yyexpected_tokens (ctx, expected, TOKENMAX);
+    /* Forward errors to yyparse.  */
+    if (n < 0)
+      res = n;
+    else if (0 < n)
       {
         fprintf (stderr, " (expected:");
-        for (int i = 1; i < n; ++i)
-          fprintf (stderr, " [%s]", yysymbol_name (arg[i]));
+        for (int i = 0; i < n; ++i)
+          fprintf (stderr, " [%s]", yysymbol_name (expected[i]));
         fprintf (stderr, ")");
       }
-    fprintf (stderr, "\n");
   }
-  return 0;
+  fprintf (stderr, "\n");
+  return res;
 }
 ]])[
 

--- a/tests/local.at
+++ b/tests/local.at
@@ -972,17 +972,24 @@ m4_define([AT_YYERROR_DEFINE(java)],
 ]AT_ERROR_CUSTOM_IF([[
   public void yyreportSyntaxError (Calc.Context ctx)
   {
-    int[] arg = new int[ctx.NTOKENS];
-    int n = ctx.yysyntaxErrorArguments (arg, ctx.NTOKENS);
     System.err.print (]AT_LOCATION_IF([[ctx.getLocation () + ": "]]
-                      + )["syntax error on token @<:@" + ctx.yysymbolName (arg[0]) + "@:>@");
-    if (1 < n)
-      {
-        System.err.print (" (expected:");
-        for (int i = 1; i < n; ++i)
-          System.err.print (" @<:@" + ctx.yysymbolName (arg[i]) + "@:>@");
-        System.err.print (")");
-      }
+                      + )["syntax error");
+    {
+      int token = ctx.getToken ();
+      if (token != ctx.EMPTY)
+        System.err.print (" on token @<:@" + ctx.yysymbolName (token) + "@:>@");
+    }
+    {
+      int[] arg = new int[ctx.NTOKENS];
+      int n = ctx.yyexpectedTokens (arg, ctx.NTOKENS);
+      if (0 < n)
+        {
+          System.err.print (" (expected:");
+          for (int i = 0; i < n; ++i)
+            System.err.print (" @<:@" + ctx.yysymbolName (arg[i]) + "@:>@");
+          System.err.print (")");
+        }
+    }
     System.err.println ("");
   }
 ]])


### PR DESCRIPTION
This series of commits explores the removal of yysyntax_error_arguments, as Adrian suggested (https://lists.gnu.org/archive/html/bison-patches/2020-02/msg00069.html). I wanted to see in practice what impact it has on the user code, and here are a few examples.

examples/c/bistromathic goes from

```c
  int
  yyreport_syntax_error (const yyparse_context_t *ctx)
  {
    enum { ARGMAX = 10 };
    int res = 0;
    int arg[ARGMAX];
    int n = yysyntax_error_arguments (ctx, arg, ARGMAX);
    if (n < 0)
      // Forward errors to yyparse.
      res = n;
    YY_LOCATION_PRINT (stderr, *yyparse_context_location (ctx));
    fprintf (stderr, ": syntax error");
    if (n >= 0)
      {
        for (int i = 1; i < n; ++i)
          fprintf (stderr, "%s %s",
                   i == 1 ? ": expected" : " or", yysymbol_name (arg[i]));
        if (n)
          fprintf (stderr, " before %s", yysymbol_name (arg[0]));
      }
    fprintf (stderr, "\n");
    return res;
  }
```
to (with a slight change of semantics: 10 unexpected vs 10 in total)

```c
  int
  yyreport_syntax_error (const yyparse_context_t *ctx)
  {
    int res = 0;
    YY_LOCATION_PRINT (stderr, *yyparse_context_location (ctx));
    fprintf (stderr, ": syntax error");
    {
      enum { TOKENMAX = 10 };
      int expected[TOKENMAX];
      int n = yyexpected_tokens (ctx, expected, TOKENMAX);
      if (n < 0)
        // Forward errors to yyparse.
        res = n;
      else
        for (int i = 0; i < n; ++i)
          fprintf (stderr, "%s %s",
                   i == 0 ? ": expected" : " or", yysymbol_name (expected[i]));
    }
    {
      int lookahead = yyparse_context_token (ctx);
      if (lookahead != YYEMPTY)
        fprintf (stderr, " before %s", yysymbol_name (lookahead));
    }
    fprintf (stderr, "\n");
    return res;
  }
```

Bison's own reporting function goes from

```c
  int
  yyreport_syntax_error (const yyparse_context_t *ctx)
  {
    enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
    /* Arguments of format: reported tokens (one for the "unexpected",
       one per "expected"). */
    int arg[YYERROR_VERBOSE_ARGS_MAXIMUM];
    int n = yysyntax_error_arguments (ctx, arg, YYERROR_VERBOSE_ARGS_MAXIMUM);
    if (n == -2)
      return -2;
    const char *argv[YYERROR_VERBOSE_ARGS_MAXIMUM];
    for (int i = 0; i < n; ++i)
      argv[i] = yysymbol_name (arg[i]);
    syntax_error (*yyparse_context_location (ctx), n, argv);
    return 0;
  }
```

to

```c
  int
  yyreport_syntax_error (const yyparse_context_t *ctx)
  {
    int res = 0;
    /* Arguments of format: reported tokens (one for the "unexpected",
       one per "expected"). */
    enum { ARGS_MAX = 5 };
    const char *argv[ARGS_MAX];
    int argc = 0;
    int unexpected = yyparse_context_token (ctx);
    if (unexpected != YYEMPTY)
      {
        argv[argc++] = yysymbol_name (unexpected);
        int expected[ARGS_MAX - 1];
        int nexpected = yyexpected_tokens (ctx, expected, ARGS_MAX - 1);
        if (nexpected < 0)
          res = nexpected;
        else
          for (int i = 0; i < nexpected; ++i)
            argv[argc++] = yysymbol_name (expected[i]);
      }
    syntax_error (*yyparse_context_location (ctx), argc, argv);
    return res;
  }
```

So, overall there is more complexity pushed onto the user.  And we have to expose her to `YYEMPTY`, which was not needed before.

These routines are also complex because of the handling of errors.  It might not be worth it: if memory is exhausted, then we will report that anyway, and quite properly.  The only difference being that we display "syntax error" before "memory exhausted".  Is this really worth the extra complexity?

So I am still hesitating, and would welcome opinions.
