### PR TITLE
Introduce a type for symbol  types

### DIFF
--- a/TODO
+++ b/TODO
@@ -53,22 +53,6 @@ would actually also make the following point gracefully handled (status of
 YYERRCODE, YYUNDEFTOK, etc.).  Possibly we could also define YYEMPTY (twice:
 as a token and as a symbol).  And YYEOF.
 
-It seems to work well.  Yet we have a weird case: the "error" token:
-
-enum yysymbol_type_t
-{
-  YYSYMBOL_YYEMPTY = -2,
-  YYSYMBOL_YYEOF = 0,
-  YYSYMBOL_error = 1,
-  YYSYMBOL_YYUNDEF = 2,
-  YYSYMBOL_YYACCEPT = 61,
-  ...
-
-YYSYMBOL_error looks weird.  We should maybe rename this as
-"YYSYMBOL_YYERROR", even though it should not be confonded with the YYERROR
-macro.
-
-
 ** Consistency
 YYUNDEFTOK is an internal symbol number, as YYTERROR.
 But YYERRCODE is an external token number.

--- a/TODO
+++ b/TODO
@@ -18,6 +18,8 @@ There is some confusion over these terms, which is even a problem for
 translators.  We need something clear, especially if we provide access to
 the symbol numbers (which would be useful for custom error messages).
 
+We could use "number" and "code".
+
 *** The documentation
 
 You can explicitly specify the numeric code for a token type...
@@ -41,6 +43,9 @@ uses "user token number" in most places.
   else if (user_token_number == INT_MAX)
     complain (&loc, complaint, _("user token number of %s too large"),
               sym->tag);
+
+*** M4
+Make it consistent with the rest (it uses "user_number" and "number").
 
 ** Symbol numbers
 Giving names to symbol numbers would be useful in custom error messages.  It

--- a/TODO
+++ b/TODO
@@ -53,6 +53,22 @@ would actually also make the following point gracefully handled (status of
 YYERRCODE, YYUNDEFTOK, etc.).  Possibly we could also define YYEMPTY (twice:
 as a token and as a symbol).  And YYEOF.
 
+It seems to work well.  Yet we have a weird case: the "error" token:
+
+enum yysymbol_type_t
+{
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,
+  YYSYMBOL_error = 1,
+  YYSYMBOL_YYUNDEF = 2,
+  YYSYMBOL_YYACCEPT = 61,
+  ...
+
+YYSYMBOL_error looks weird.  We should maybe rename this as
+"YYSYMBOL_YYERROR", even though it should not be confonded with the YYERROR
+macro.
+
+
 ** Consistency
 YYUNDEFTOK is an internal symbol number, as YYTERROR.
 But YYERRCODE is an external token number.

--- a/data/skeletons/bison.m4
+++ b/data/skeletons/bison.m4
@@ -384,22 +384,21 @@ m4_define([b4_glr_cc_if],
 ## Symbols.  ##
 ## --------- ##
 
-# For a description of the Symbol handling, see README.
+# For a description of the Symbol handling, see README.md.
 #
 # The following macros provide access to symbol related values.
 
 # __b4_symbol(NUM, FIELD)
 # -----------------------
-# Recover a FIELD about symbol #NUM.  Thanks to m4_indir, fails if
-# undefined.
+# Fetch FIELD of symbol #NUM.  Fail if undefined.
 m4_define([__b4_symbol],
 [m4_indir([b4_symbol($1, $2)])])
 
 
 # _b4_symbol(NUM, FIELD)
 # ----------------------
-# Recover a FIELD about symbol #NUM (or "orig NUM").  Fails if
-# undefined.
+# Fetch FIELD of symbol #NUM (or "orig NUM", see README.md).
+# Fail if undefined.
 m4_define([_b4_symbol],
 [m4_ifdef([b4_symbol($1, number)],
           [__b4_symbol(m4_indir([b4_symbol($1, number)]), $2)],
@@ -409,8 +408,9 @@ m4_define([_b4_symbol],
 
 # b4_symbol(NUM, FIELD)
 # ---------------------
-# Recover a FIELD about symbol #NUM (or "orig NUM").  Fails if
-# undefined.  If FIELD = id, prepend the token prefix.
+# Fetch FIELD of symbol #NUM (or "orig NUM").  Fail if undefined.
+#
+# If FIELD = id, prepend the token prefix.
 m4_define([b4_symbol],
 [m4_case([$2],
          [id],    [m4_do([b4_percent_define_get([api.token.prefix])],
@@ -530,6 +530,7 @@ m4_define([b4_any_token_visible_if],
 
 # b4_token_format(FORMAT, NUM)
 # ----------------------------
+# If token NUM has a visible ID, format FORMAT with ID, USER_NUMBER.
 m4_define([b4_token_format],
 [b4_token_visible_if([$2],
 [m4_format([[$1]],

--- a/data/skeletons/bison.m4
+++ b/data/skeletons/bison.m4
@@ -407,8 +407,10 @@ m4_define([_b4_symbol],
 
 # b4_symbol_sid(NUM)
 # ------------------
-# Build the symbol ID based for this symbol.  Return empty
-# if that would produce an invalid symbol.
+# Build the symbol ID based for this symbol.  It must always exist,
+# otherwise some symbols might not be represented in the enum, which
+# might be compiled into too small a type to contain all the symbol
+# numbers.
 m4_define([b4_symbol_sid],
 [m4_case([$1],
   [-2],                           [[YYSYMBOL_YYEMPTY]],
@@ -417,8 +419,9 @@ m4_define([b4_symbol_sid],
       [$accept],                  [[YYSYMBOL_YYACCEPT]],
       [error],                    [[YYSYMBOL_YYERROR]],
       [$undefined],               [[YYSYMBOL_YYUNDEF]],
-      [m4_quote(b4_symbol_if([$1], [has_id],
-                                  [[YYSYMBOL_]]m4_quote(_b4_symbol([$1], [id]))))])])])
+      [b4_symbol_if([$1], [has_id],
+                                  [[YYSYMBOL_]]m4_quote(_b4_symbol([$1], [id])),
+                                  [[YYSYMBOL_$1_][]m4_bpatsubst(m4_quote(_b4_symbol([$1], [tag])), [[^a-zA-Z_0-9]], [_])])])])])
 
 
 # b4_symbol(NUM, FIELD)

--- a/data/skeletons/bison.m4
+++ b/data/skeletons/bison.m4
@@ -411,6 +411,7 @@ m4_define([_b4_symbol],
 # if that would produce an invalid symbol.
 m4_define([b4_symbol_sid],
 [m4_case([$1],
+  [-2],                           [[YYSYMBOL_YYEMPTY]],
   [0],                            [[YYSYMBOL_YYEOF]],
   [m4_bmatch(m4_quote(b4_symbol([$1], [tag])),
       [^\$accept$],               [[YYSYMBOL_YYACCEPT]],

--- a/data/skeletons/bison.m4
+++ b/data/skeletons/bison.m4
@@ -413,9 +413,10 @@ m4_define([b4_symbol_sid],
 [m4_case([$1],
   [-2],                           [[YYSYMBOL_YYEMPTY]],
   [0],                            [[YYSYMBOL_YYEOF]],
-  [m4_bmatch(m4_quote(b4_symbol([$1], [tag])),
-      [^\$accept$],               [[YYSYMBOL_YYACCEPT]],
-      [^\$undefined$],            [[YYSYMBOL_YYUNDEF]],
+  [m4_case(m4_quote(b4_symbol([$1], [tag])),
+      [$accept],                  [[YYSYMBOL_YYACCEPT]],
+      [error],                    [[YYSYMBOL_YYERROR]],
+      [$undefined],               [[YYSYMBOL_YYUNDEF]],
       [m4_quote(b4_symbol_if([$1], [has_id],
                                   [[YYSYMBOL_]]m4_quote(_b4_symbol([$1], [id]))))])])])
 

--- a/data/skeletons/bison.m4
+++ b/data/skeletons/bison.m4
@@ -405,6 +405,19 @@ m4_define([_b4_symbol],
           [__b4_symbol([$1], [$2])])])
 
 
+# b4_symbol_sid(NUM)
+# ------------------
+# Build the symbol ID based for this symbol.  Return empty
+# if that would produce an invalid symbol.
+m4_define([b4_symbol_sid],
+[m4_case([$1],
+  [0],                            [[YYSYMBOL_YYEOF]],
+  [m4_bmatch(m4_quote(b4_symbol([$1], [tag])),
+      [^\$accept$],               [[YYSYMBOL_YYACCEPT]],
+      [^\$undefined$],            [[YYSYMBOL_YYUNDEF]],
+      [m4_quote(b4_symbol_if([$1], [has_id],
+                                  [[YYSYMBOL_]]m4_quote(_b4_symbol([$1], [id]))))])])])
+
 
 # b4_symbol(NUM, FIELD)
 # ---------------------
@@ -415,6 +428,7 @@ m4_define([b4_symbol],
 [m4_case([$2],
          [id],    [m4_do([b4_percent_define_get([api.token.prefix])],
                          [_b4_symbol([$1], [id])])],
+         [sid],   [b4_symbol_sid([$1])],
          [_b4_symbol($@)])])
 
 

--- a/data/skeletons/c++.m4
+++ b/data/skeletons/c++.m4
@@ -265,11 +265,8 @@ m4_define([b4_public_types_declare],
     /// (External) token type, as returned by yylex.
     typedef token::yytokentype token_type;
 
-    /// Symbol codes.
+    /// (Internal) symbol codes.
     ]b4_declare_symbol_enum[
-
-    /// Symbol type: an internal symbol number.
-    typedef symbol_type_type symbol_number_type;
 ]])
 
 
@@ -325,7 +322,7 @@ m4_define([b4_symbol_type_define],
       void clear ()
       {]b4_variant_if([[
         // User destructor.
-        symbol_number_type yytype = this->type_get ();
+        symbol_type_type yytype = this->type_get ();
         basic_symbol<Base>& yysym = *this;
         (void) yysym;
         switch (yytype)
@@ -387,11 +384,11 @@ m4_define([b4_symbol_type_define],
 
       /// The (internal) type number (corresponding to \a type).
       /// \a empty when empty.
-      symbol_number_type type_get () const YY_NOEXCEPT;
+      symbol_type_type type_get () const YY_NOEXCEPT;
 
       /// The symbol type.
       /// \a YYSYMBOL_YYEMPTY when empty.
-      symbol_number_type type;
+      symbol_type_type type;
     };
 
     /// "External" symbols: returned by the scanner.
@@ -511,7 +508,7 @@ m4_define([b4_public_types_define],
     that.clear ();
   }
 
-  ]b4_inline([$1])[]b4_parser_class[::symbol_number_type
+  ]b4_inline([$1])[]b4_parser_class[::symbol_type_type
   ]b4_parser_class[::by_type::type_get () const YY_NOEXCEPT
   {
     return type;
@@ -531,11 +528,11 @@ m4_define([b4_token_constructor_define], [])
 # Define yytranslate_.  Sometimes used in the header file ($1=hh),
 # sometimes in the cc file.
 m4_define([b4_yytranslate_define],
-[  b4_inline([$1])b4_parser_class[::symbol_number_type
+[  b4_inline([$1])b4_parser_class[::symbol_type_type
   ]b4_parser_class[::yytranslate_ (int t)
   {
 ]b4_api_token_raw_if(
-[[    return static_cast<symbol_number_type> (t);]],
+[[    return static_cast<symbol_type_type> (t);]],
 [[    // YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to
     // TOKEN-NUM as returned by yylex.
     static
@@ -549,7 +546,7 @@ m4_define([b4_yytranslate_define],
     if (t <= 0)
       return YYSYMBOL_YYEOF;
     else if (t <= user_token_number_max_)
-      return YY_CAST (symbol_number_type, translate_table[t]);
+      return YY_CAST (symbol_type_type, translate_table[t]);
     else
       return YYSYMBOL_YYUNDEF;]])[
   }

--- a/data/skeletons/c.m4
+++ b/data/skeletons/c.m4
@@ -425,9 +425,9 @@ static const b4_int_type_for([$2]) yy$1[[]] =
 ])
 
 
-## ------------------------- ##
-## Assigning token numbers.  ##
-## ------------------------- ##
+## -------------------------- ##
+## (External) token numbers.  ##
+## -------------------------- ##
 
 # b4_token_define(TOKEN-NUM)
 # --------------------------
@@ -454,7 +454,7 @@ m4_define([b4_token_enum],
 
 # b4_token_enums
 # --------------
-# Output the definition of the tokens (if there are) as enums.
+# The definition of the tokens (if there are) as enums.
 m4_define([b4_token_enums],
 [b4_any_token_visible_if([[/* Token type.  */
 #ifndef ]b4_api_PREFIX[TOKENTYPE
@@ -471,7 +471,7 @@ m4_define([b4_token_enums],
 
 # b4_token_enums_defines
 # ----------------------
-# Output the definition of the tokens (if there are any) as enums and,
+# The definition of the tokens (if there are any) as enums and,
 # if POSIX Yacc is enabled, as #defines.
 m4_define([b4_token_enums_defines],
 [b4_token_enums[]b4_yacc_if([b4_token_defines])])

--- a/data/skeletons/c.m4
+++ b/data/skeletons/c.m4
@@ -486,6 +486,36 @@ m4_define([b4_symbol_translate],
 
 
 
+## --------------------------- ##
+## (Internal) symbol numbers.  ##
+## --------------------------- ##
+
+
+# b4_symbol_enum(SYMBOL-NUM)
+# --------------------------
+# Output the definition of this symbol as an enum.
+m4_define([b4_symbol_enum],
+[m4_ifval(b4_symbol([$1], [sid]),
+         [m4_format([[%s = %s]],
+                    b4_symbol([$1], [sid]),
+                    b4_symbol([$1], [number]))])])
+
+
+# b4_declare_symbol_enum
+# ----------------------
+# The definition of the symbol internal numbers as an enum.
+m4_define([b4_declare_symbol_enum],
+[[/* Symbol type.  */
+enum yysymbol_type_t
+{
+  ]m4_join([,
+  ],
+           b4_symbol_map([b4_symbol_enum]))[
+};
+typedef enum yysymbol_type_t yysymbol_type_t;
+]])])
+
+
 ## ----------------- ##
 ## Semantic Values.  ##
 ## ----------------- ##

--- a/data/skeletons/c.m4
+++ b/data/skeletons/c.m4
@@ -620,7 +620,7 @@ m4_define_default([b4_yydestruct_define],
 
 static void
 yydestruct (const char *yymsg,
-            int yytype, YYSTYPE *yyvaluep]b4_locations_if(dnl
+            yysymbol_type_t yytype, YYSTYPE *yyvaluep]b4_locations_if(dnl
 [[, YYLTYPE *yylocationp]])[]b4_user_formals[)
 {
 ]b4_parse_param_use([yyvaluep], [yylocationp])dnl
@@ -646,7 +646,7 @@ m4_define_default([b4_yy_symbol_print_define],
 
 static void
 yy_symbol_value_print (FILE *yyo,
-                       int yytype, YYSTYPE const * const yyvaluep]b4_locations_if(dnl
+                       yysymbol_type_t yytype, YYSTYPE const * const yyvaluep]b4_locations_if(dnl
 [[, YYLTYPE const * const yylocationp]])[]b4_user_formals[)
 {
   FILE *yyoutput = yyo;
@@ -674,7 +674,7 @@ b4_percent_code_get([[post-printer]])dnl
 
 static void
 yy_symbol_print (FILE *yyo,
-                 int yytype, YYSTYPE const * const yyvaluep]b4_locations_if(dnl
+                 yysymbol_type_t yytype, YYSTYPE const * const yyvaluep]b4_locations_if(dnl
 [[, YYLTYPE const * const yylocationp]])[]b4_user_formals[)
 {
   YYFPRINTF (yyo, "%s %s (",

--- a/data/skeletons/c.m4
+++ b/data/skeletons/c.m4
@@ -504,12 +504,15 @@ m4_define([b4_symbol_enum],
 # b4_declare_symbol_enum
 # ----------------------
 # The definition of the symbol internal numbers as an enum.
+# Defining YYEMPTY here is important: it forces the compiler
+# to use a signed type, which matters for yytoken.
 m4_define([b4_declare_symbol_enum],
 [[/* Symbol type.  */
 enum yysymbol_type_t
 {
   ]m4_join([,
   ],
+           ]b4_symbol_sid([-2])[ = -2,
            b4_symbol_map([b4_symbol_enum]))[
 };
 typedef enum yysymbol_type_t yysymbol_type_t;

--- a/data/skeletons/glr.c
+++ b/data/skeletons/glr.c
@@ -488,9 +488,6 @@ typedef int yy_state_t;
 /** Rule numbers. */
 typedef int yyRuleNum;
 
-/** Grammar symbol. */
-typedef yysymbol_type_t yySymbol;
-
 /** Item references. */
 typedef short yyItemNum;
 
@@ -597,16 +594,16 @@ yyMemoryExhausted (yyGLRStack* yystackp)
 }
 
 /** Accessing symbol of state YYSTATE.  */
-static inline yySymbol
+static inline yysymbol_type_t
 yy_accessing_symbol (yy_state_t yystate)
 {
-  return YY_CAST (yySymbol, yystos[yystate]);
+  return YY_CAST (yysymbol_type_t, yystos[yystate]);
 }
 
 #if ]b4_parse_error_case([simple], [b4_api_PREFIX[DEBUG || ]b4_token_table_flag], [[1]])[
 /* The user-facing name of the symbol whose (internal) number is
    YYSYMBOL.  No bounds checking.  */
-static const char *yysymbol_name (yySymbol yysymbol) YY_ATTRIBUTE_UNUSED;
+static const char *yysymbol_name (yysymbol_type_t yysymbol) YY_ATTRIBUTE_UNUSED;
 
 ]b4_parse_error_bmatch([simple\|verbose],
 [[/* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
@@ -617,12 +614,12 @@ static const char *const yytname[] =
 };
 
 static const char *
-yysymbol_name (yySymbol yysymbol)
+yysymbol_name (yysymbol_type_t yysymbol)
 {
   return yytname[yysymbol];
 }]],
 [[static const char *
-yysymbol_name (yySymbol yysymbol)
+yysymbol_name (yysymbol_type_t yysymbol)
 {
   static const char *const yy_sname[] =
   {
@@ -808,10 +805,10 @@ yyfillin (yyGLRStackItem *yyvsp, int yylow0, int yylow1)
 ]m4_define([b4_yygetToken_call],
            [[yygetToken (&yychar][]b4_pure_if([, yystackp])[]b4_user_args[)]])[
 /** If yychar is empty, fetch the next token.  */
-static inline yySymbol
+static inline yysymbol_type_t
 yygetToken (int *yycharp][]b4_pure_if([, yyGLRStack* yystackp])[]b4_user_formals[)
 {
-  yySymbol yytoken;
+  yysymbol_type_t yytoken;
 ]b4_parse_param_use()dnl
 [  if (*yycharp == YYEMPTY)
     {
@@ -997,10 +994,10 @@ yydestroyGLRState (char const *yymsg, yyGLRState *yys]b4_user_formals[)
 }
 
 /** Left-hand-side symbol for rule #YYRULE.  */
-static inline yySymbol
+static inline yysymbol_type_t
 yylhsNonterm (yyRuleNum yyrule)
 {
-  return YY_CAST (yySymbol, yyr1[yyrule]);
+  return YY_CAST (yysymbol_type_t, yyr1[yyrule]);
 }
 
 #define yypact_value_is_default(Yyn) \
@@ -1033,7 +1030,7 @@ yydefaultAction (yy_state_t yystate)
  *  of conflicting reductions.
  */
 static inline int
-yygetLRActions (yy_state_t yystate, yySymbol yytoken, const short** yyconflicts)
+yygetLRActions (yy_state_t yystate, yysymbol_type_t yytoken, const short** yyconflicts)
 {
   int yyindex = yypact[yystate] + yytoken;
   if (yyisDefaultedState (yystate)
@@ -1059,7 +1056,7 @@ yygetLRActions (yy_state_t yystate, yySymbol yytoken, const short** yyconflicts)
  * \param yysym     the nonterminal to push on the stack
  */
 static inline yy_state_t
-yyLRgotoState (yy_state_t yystate, yySymbol yysym)
+yyLRgotoState (yy_state_t yystate, yysymbol_type_t yysym)
 {
   int yyr = yypgoto[yysym - YYNTOKENS] + yystate;
   if (0 <= yyr && yyr <= YYLAST && yycheck[yyr] == yystate)
@@ -2030,7 +2027,7 @@ yyprocessOneStack (yyGLRStack* yystackp, ptrdiff_t yyk,
         }
       else
         {
-          yySymbol yytoken = ]b4_yygetToken_call[;
+          yysymbol_type_t yytoken = ]b4_yygetToken_call[;
           const short* yyconflicts;
           const int yyaction = yygetLRActions (yystate, yytoken, &yyconflicts);
           yystackp->yytops.yylookaheadNeeds[yyk] = yytrue;
@@ -2093,7 +2090,7 @@ yyprocessOneStack (yyGLRStack* yystackp, ptrdiff_t yyk,
    be less than YYNTOKENS).  */
 static int
 yyexpected_tokens (const yyGLRStack* yystackp,
-                   yySymbol yyarg[], int yyargn)
+                   yysymbol_type_t yyarg[], int yyargn)
 {
   /* Actual size of YYARG. */
   int yycount = 0;
@@ -2117,7 +2114,7 @@ yyexpected_tokens (const yyGLRStack* yystackp,
             else if (yycount == yyargn)
               return 0;
             else
-              yyarg[yycount++] = YY_CAST (yySymbol, yyx);
+              yyarg[yycount++] = YY_CAST (yysymbol_type_t, yyx);
           }
     }
   return yycount;
@@ -2131,14 +2128,14 @@ static int
 yyreport_syntax_error (const yyGLRStack* yystackp]b4_user_formals[);
 
 /* The token type of the lookahead of this context.  */
-static yySymbol
+static yysymbol_type_t
 yyparse_context_token (const yyGLRStack *yystackp) YY_ATTRIBUTE_UNUSED;
 
-static yySymbol
+static yysymbol_type_t
 yyparse_context_token (const yyGLRStack *yystackp)
 {
   YYUSE (yystackp);
-  yySymbol yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
+  yysymbol_type_t yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   return yytoken;
 }
 
@@ -2155,9 +2152,9 @@ yyparse_context_location (const yyGLRStack *yystackp)
          [detailed\|verbose],
 [[static int
 yysyntax_error_arguments (const yyGLRStack* yystackp,
-                          yySymbol yyarg[], int yyargn)
+                          yysymbol_type_t yyarg[], int yyargn)
 {
-  yySymbol yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
+  yysymbol_type_t yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* Actual size of YYARG. */
   int yycount = 0;
   /* There are many possibilities here to consider:
@@ -2222,7 +2219,7 @@ yyreportSyntaxError (yyGLRStack* yystackp]b4_user_formals[)
   const char *yyformat = YY_NULLPTR;
   /* Arguments of yyformat: reported tokens (one for the "unexpected",
      one per "expected"). */
-  yySymbol yyarg[YYARGS_MAX];
+  yysymbol_type_t yyarg[YYARGS_MAX];
   /* Cumulated lengths of YYARG.  */
   ptrdiff_t yysize = 0;
 
@@ -2310,7 +2307,7 @@ yyrecoverSyntaxError (yyGLRStack* yystackp]b4_user_formals[)
        reductions.  Skip tokens until we can proceed.  */
     while (yytrue)
       {
-        yySymbol yytoken;
+        yysymbol_type_t yytoken;
         int yyj;
         if (yychar == YYEOF)
           yyFail (yystackp][]b4_lpure_args[, YY_NULLPTR);
@@ -2468,7 +2465,7 @@ b4_dollar_popdef])[]dnl
             }
           else
             {
-              yySymbol yytoken = ]b4_yygetToken_call;[
+              yysymbol_type_t yytoken = ]b4_yygetToken_call;[
               const short* yyconflicts;
               int yyaction = yygetLRActions (yystate, yytoken, &yyconflicts);
               if (*yyconflicts != 0)
@@ -2498,7 +2495,7 @@ b4_dollar_popdef])[]dnl
 
       while (yytrue)
         {
-          yySymbol yytoken_to_shift;
+          yysymbol_type_t yytoken_to_shift;
           ptrdiff_t yys;
 
           for (yys = 0; yys < yystack.yytops.yysize; yys += 1)

--- a/data/skeletons/glr.c
+++ b/data/skeletons/glr.c
@@ -1482,7 +1482,7 @@ yyglrReduce (yyGLRStack* yystackp, ptrdiff_t yyk, yyRuleNum yyrule,
                      YY_CAST (long, yyk), yyrule - 1, yyrline[yyrule - 1]));
       if (yyflag != yyok)
         return yyflag;
-      YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyrule], &yysval, &yyloc);
+      YY_SYMBOL_PRINT ("-> $$ =", yylhsNonterm (yyrule), &yysval, &yyloc);
       yyglrShift (yystackp, yyk,
                   yyLRgotoState (yystackp->yytops.yystates[yyk]->yylrState,
                                  yylhsNonterm (yyrule)),
@@ -2131,10 +2131,10 @@ static int
 yyreport_syntax_error (const yyGLRStack* yystackp]b4_user_formals[);
 
 /* The token type of the lookahead of this context.  */
-static int
+static yySymbol
 yyparse_context_token (const yyGLRStack *yystackp) YY_ATTRIBUTE_UNUSED;
 
-static int
+static yySymbol
 yyparse_context_token (const yyGLRStack *yystackp)
 {
   YYUSE (yystackp);

--- a/data/skeletons/glr.c
+++ b/data/skeletons/glr.c
@@ -230,6 +230,7 @@ b4_copyright([Skeleton implementation for Bison GLR parsers in C],
 
 ]b4_defines_if([[#include "@basename(]b4_spec_header_file[@)"]],
                [b4_shared_declarations])[
+]b4_declare_symbol_enum[
 
 /* Default (constant) value used for initialization for null
    right-hand sides.  Unlike the standard yacc.c template, here we set
@@ -332,16 +333,15 @@ static YYLTYPE yyloc_default][]b4_yyloc_default;])[
 /* YYFAULTYTOK -- Token number (for yychar) that denotes a
    syntax_error thrown from the scanner.  */
 #define YYFAULTYTOK (YYMAXUTOK + 1)]])[
-/* YYUNDEFTOK -- Symbol number (for yytoken) that denotes an unknown
-   token.  */
-#define YYUNDEFTOK  ]b4_undef_token_number[
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex, with out-of-bounds checking.  */
 ]b4_api_token_raw_if(dnl
-[[#define YYTRANSLATE(YYX) (YYX)]],
-[[#define YYTRANSLATE(YYX)                         \
-  (0 <= (YYX) && (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+[[#define YYTRANSLATE(YYX) YY_CAST (yysymbol_type_t, YYX)]],
+[[#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_type_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex.  */
@@ -400,9 +400,6 @@ dnl We probably ought to introduce a type for confl.
 {
   ]b4_conflicting_rules[
 };
-
-/* Error token number */
-#define YYTERROR 1
 
 ]b4_locations_if([[
 ]b4_yylloc_default_define[
@@ -492,7 +489,7 @@ typedef int yy_state_t;
 typedef int yyRuleNum;
 
 /** Grammar symbol. */
-typedef int yySymbol;
+typedef yysymbol_type_t yySymbol;
 
 /** Item references. */
 typedef short yyItemNum;
@@ -597,6 +594,13 @@ _Noreturn static void
 yyMemoryExhausted (yyGLRStack* yystackp)
 {
   YYLONGJMP (yystackp->yyexception_buffer, 2);
+}
+
+/** Accessing symbol of state YYSTATE.  */
+static inline yySymbol
+yy_accessing_symbol (yy_state_t yystate)
+{
+  return YY_CAST (yySymbol, yystos[yystate]);
 }
 
 #if ]b4_parse_error_case([simple], [b4_api_PREFIX[DEBUG || ]b4_token_table_flag], [[1]])[
@@ -824,9 +828,9 @@ yygetToken (int *yycharp][]b4_pure_if([, yyGLRStack* yystackp])[]b4_user_formals
           YY_DPRINTF ((stderr, "Caught exception: %s\n", yyexc.what()));]b4_locations_if([
           yylloc = yyexc.location;])[
           yyerror (]b4_lyyerror_args[yyexc.what ());
-          // Map errors caught in the scanner to the undefined token
-          // (YYUNDEFTOK), so that error handling is started.
-          // However, record this with this special value of yychar.
+          // Map errors caught in the scanner to the undefined token,
+          // so that error handling is started.  However, record this
+          // with this special value of yychar.
           *yycharp = YYFAULTYTOK;
         }
 #endif // YY_EXCEPTIONS]], [[
@@ -834,7 +838,8 @@ yygetToken (int *yycharp][]b4_pure_if([, yyGLRStack* yystackp])[]b4_user_formals
     }
   if (*yycharp <= YYEOF)
     {
-      *yycharp = yytoken = YYEOF;
+      *yycharp = YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YY_DPRINTF ((stderr, "Now at end of input.\n"));
     }
   else
@@ -963,7 +968,7 @@ static void
 yydestroyGLRState (char const *yymsg, yyGLRState *yys]b4_user_formals[)
 {
   if (yys->yyresolved)
-    yydestruct (yymsg, yystos[yys->yylrState],
+    yydestruct (yymsg, yy_accessing_symbol (yys->yylrState),
                 &yys->yysemantics.yysval]b4_locuser_args([&yys->yyloc])[);
   else
     {
@@ -974,7 +979,7 @@ yydestroyGLRState (char const *yymsg, yyGLRState *yys]b4_user_formals[)
             YY_FPRINTF ((stderr, "%s unresolved", yymsg));
           else
             YY_FPRINTF ((stderr, "%s incomplete", yymsg));
-          YY_SYMBOL_PRINT ("", yystos[yys->yylrState], YY_NULLPTR, &yys->yyloc);
+          YY_SYMBOL_PRINT ("", yy_accessing_symbol (yys->yylrState), YY_NULLPTR, &yys->yyloc);
         }
 #endif
 
@@ -995,7 +1000,7 @@ yydestroyGLRState (char const *yymsg, yyGLRState *yys]b4_user_formals[)
 static inline yySymbol
 yylhsNonterm (yyRuleNum yyrule)
 {
-  return yyr1[yyrule];
+  return YY_CAST (yySymbol, yyr1[yyrule]);
 }
 
 #define yypact_value_is_default(Yyn) \
@@ -1390,7 +1395,7 @@ yy_reduce_print (yybool yynormal, yyGLRStackItem* yyvsp, ptrdiff_t yyk,
     {
       YY_FPRINTF ((stderr, "   $%d = ", yyi + 1));
       yy_symbol_print (stderr,
-                       yystos[yyvsp[yyi - yynrhs + 1].yystate.yylrState],
+                       yy_accessing_symbol (yyvsp[yyi - yynrhs + 1].yystate.yylrState),
                        &yyvsp[yyi - yynrhs + 1].yystate.yysemantics.yysval]b4_locations_if([,
                        &]b4_rhs_location(yynrhs, yyi + 1))[]dnl
                        b4_user_args[);
@@ -1771,10 +1776,10 @@ yyreportTree (yySemanticOption* yyx, int yyindent)
         {
           if (yystates[yyi-1]->yyposn+1 > yystates[yyi]->yyposn)
             YY_FPRINTF ((stderr, "%*s%s <empty>\n", yyindent+2, "",
-                         yysymbol_name (yystos[yystates[yyi]->yylrState])));
+                         yysymbol_name (yy_accessing_symbol (yystates[yyi]->yylrState))));
           else
             YY_FPRINTF ((stderr, "%*s%s <tokens %ld .. %ld>\n", yyindent+2, "",
-                         yysymbol_name (yystos[yystates[yyi]->yylrState]),
+                         yysymbol_name (yy_accessing_symbol (yystates[yyi]->yylrState)),
                          YY_CAST (long, yystates[yyi-1]->yyposn + 1),
                          YY_CAST (long, yystates[yyi]->yyposn)));
         }
@@ -1919,7 +1924,7 @@ yyresolveValue (yyGLRState* yys, yyGLRStack* yystackp]b4_user_formals[)
                 if (yyflag != yyok)
                   {
                     yydestruct ("Cleanup: discarding incompletely merged value for",
-                                yystos[yys->yylrState],
+                                yy_accessing_symbol (yys->yylrState),
                                 &yysval]b4_locuser_args[);
                     break;
                   }
@@ -2088,7 +2093,7 @@ yyprocessOneStack (yyGLRStack* yystackp, ptrdiff_t yyk,
    be less than YYNTOKENS).  */
 static int
 yyexpected_tokens (const yyGLRStack* yystackp,
-                   int yyarg[], int yyargn)
+                   yySymbol yyarg[], int yyargn)
 {
   /* Actual size of YYARG. */
   int yycount = 0;
@@ -2104,7 +2109,7 @@ yyexpected_tokens (const yyGLRStack* yystackp,
       int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
       int yyx;
       for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-        if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
+        if (yycheck[yyx + yyn] == yyx && yyx != YYSYMBOL_YYERROR
             && !yytable_value_is_error (yytable[yyx + yyn]))
           {
             if (!yyarg)
@@ -2112,7 +2117,7 @@ yyexpected_tokens (const yyGLRStack* yystackp,
             else if (yycount == yyargn)
               return 0;
             else
-              yyarg[yycount++] = yyx;
+              yyarg[yycount++] = YY_CAST (yySymbol, yyx);
           }
     }
   return yycount;
@@ -2133,7 +2138,7 @@ static int
 yyparse_context_token (const yyGLRStack *yystackp)
 {
   YYUSE (yystackp);
-  yySymbol yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
+  yySymbol yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   return yytoken;
 }
 
@@ -2150,9 +2155,9 @@ yyparse_context_location (const yyGLRStack *yystackp)
          [detailed\|verbose],
 [[static int
 yysyntax_error_arguments (const yyGLRStack* yystackp,
-                          int yyarg[], int yyargn)
+                          yySymbol yyarg[], int yyargn)
 {
-  yySymbol yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
+  yySymbol yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* Actual size of YYARG. */
   int yycount = 0;
   /* There are many possibilities here to consider:
@@ -2183,7 +2188,7 @@ yysyntax_error_arguments (const yyGLRStack* yystackp,
        one exception: it will still contain any token that will not be
        accepted due to an error action in a later state.]])[
   */
-  if (yytoken != YYEMPTY)
+  if (yytoken != YYSYMBOL_YYEMPTY)
     {
       int yyn;
       yyarg[yycount++] = yytoken;
@@ -2359,8 +2364,8 @@ yyrecoverSyntaxError (yyGLRStack* yystackp]b4_user_formals[)
       int yyj = yypact[yys->yylrState];
       if (! yypact_value_is_default (yyj))
         {
-          yyj += YYTERROR;
-          if (0 <= yyj && yyj <= YYLAST && yycheck[yyj] == YYTERROR
+          yyj += YYSYMBOL_YYERROR;
+          if (0 <= yyj && yyj <= YYLAST && yycheck[yyj] == YYSYMBOL_YYERROR
               && yyisShiftAction (yytable[yyj]))
             {
               /* Shift the error token.  */
@@ -2369,7 +2374,7 @@ yyrecoverSyntaxError (yyGLRStack* yystackp]b4_user_formals[)
               YYLTYPE yyerrloc;
               yystackp->yyerror_range[2].yystate.yyloc = yylloc;
               YYLLOC_DEFAULT (yyerrloc, (yystackp->yyerror_range), 2);]])[
-              YY_SYMBOL_PRINT ("Shifting", yystos[yyaction],
+              YY_SYMBOL_PRINT ("Shifting", yy_accessing_symbol (yyaction),
                                &yylval, &yyerrloc);
               yyglrShift (yystackp, 0, yyaction,
                           yys->yyposn, &yylval]b4_locations_if([, &yyerrloc])[);

--- a/data/skeletons/glr.cc
+++ b/data/skeletons/glr.cc
@@ -66,19 +66,24 @@ m4_defn([b4_parse_param]))],
            [[b4_namespace_ref::b4_parser_class[& yyparser], [[yyparser]]]])
 ])
 
+# b4_declare_symbol_enum
+# ----------------------
+m4_append([b4_declare_symbol_enum],
+[[typedef symbol_type_type yysymbol_type_t;
+]])
+
 
 # b4_yy_symbol_print_define
 # -------------------------
 # Bypass the default implementation to generate the "yy_symbol_print"
 # and "yy_symbol_value_print" functions.
 m4_define([b4_yy_symbol_print_define],
-[[
-/*--------------------.
+[[/*--------------------.
 | Print this symbol.  |
 `--------------------*/
 
 static void
-yy_symbol_print (FILE *, int yytype,
+yy_symbol_print (FILE *, ]b4_namespace_ref::b4_parser_class[::symbol_number_type yytype,
                  const ]b4_namespace_ref::b4_parser_class[::semantic_type *yyvaluep]b4_locations_if([[,
                  const ]b4_namespace_ref::b4_parser_class[::location_type *yylocationp]])[]b4_user_formals[)
 {
@@ -170,7 +175,7 @@ m4_pushdef([b4_parse_param], m4_defn([b4_parse_param_orig]))dnl
   `--------------------*/
 
   void
-  ]b4_parser_class[::yy_symbol_value_print_ (int yytype,
+  ]b4_parser_class[::yy_symbol_value_print_ (symbol_number_type yytype,
                            const semantic_type* yyvaluep]b4_locations_if([[,
                            const location_type* yylocationp]])[)
   {]b4_locations_if([[
@@ -184,7 +189,7 @@ m4_pushdef([b4_parse_param], m4_defn([b4_parse_param_orig]))dnl
 
 
   void
-  ]b4_parser_class[::yy_symbol_print_ (int yytype,
+  ]b4_parser_class[::yy_symbol_print_ (symbol_number_type yytype,
                            const semantic_type* yyvaluep]b4_locations_if([[,
                            const location_type* yylocationp]])[)
   {
@@ -320,14 +325,14 @@ b4_percent_code_get([[requires]])[
     /// \param yytype       The token type.
     /// \param yyvaluep     Its semantic value.]b4_locations_if([[
     /// \param yylocationp  Its location.]])[
-    virtual void yy_symbol_value_print_ (int yytype,
+    virtual void yy_symbol_value_print_ (symbol_number_type yytype,
                                          const semantic_type* yyvaluep]b4_locations_if([[,
                                          const location_type* yylocationp]])[);
     /// \brief Report a symbol on the debug stream.
     /// \param yytype       The token type.
     /// \param yyvaluep     Its semantic value.]b4_locations_if([[
     /// \param yylocationp  Its location.]])[
-    virtual void yy_symbol_print_ (int yytype,
+    virtual void yy_symbol_print_ (symbol_number_type yytype,
                                    const semantic_type* yyvaluep]b4_locations_if([[,
                                    const location_type* yylocationp]])[);
   private:
@@ -350,6 +355,13 @@ b4_percent_define_flag_if([[global_tokens_and_yystype]],
 #endif
 
 ]b4_namespace_close[
+]m4_define([b4_declare_symbol_enum],
+[[typedef ]b4_namespace_ref[::]b4_parser_class[::symbol_number_type yysymbol_type_t;
+#define YYSYMBOL_YYEMPTY ]b4_namespace_ref[::]b4_parser_class[::YYSYMBOL_YYEMPTY
+#define YYSYMBOL_YYERROR ]b4_namespace_ref[::]b4_parser_class[::YYSYMBOL_YYERROR
+#define YYSYMBOL_YYEOF   ]b4_namespace_ref[::]b4_parser_class[::YYSYMBOL_YYEOF
+#define YYSYMBOL_YYUNDEF ]b4_namespace_ref[::]b4_parser_class[::YYSYMBOL_YYUNDEF
+]])[
 ]b4_percent_code_get([[provides]])[
 ]m4_popdef([b4_parse_param])dnl
 ])

--- a/data/skeletons/glr.cc
+++ b/data/skeletons/glr.cc
@@ -83,7 +83,7 @@ m4_define([b4_yy_symbol_print_define],
 `--------------------*/
 
 static void
-yy_symbol_print (FILE *, ]b4_namespace_ref::b4_parser_class[::symbol_number_type yytype,
+yy_symbol_print (FILE *, ]b4_namespace_ref::b4_parser_class[::symbol_type_type yytype,
                  const ]b4_namespace_ref::b4_parser_class[::semantic_type *yyvaluep]b4_locations_if([[,
                  const ]b4_namespace_ref::b4_parser_class[::location_type *yylocationp]])[]b4_user_formals[)
 {
@@ -175,7 +175,7 @@ m4_pushdef([b4_parse_param], m4_defn([b4_parse_param_orig]))dnl
   `--------------------*/
 
   void
-  ]b4_parser_class[::yy_symbol_value_print_ (symbol_number_type yytype,
+  ]b4_parser_class[::yy_symbol_value_print_ (symbol_type_type yytype,
                            const semantic_type* yyvaluep]b4_locations_if([[,
                            const location_type* yylocationp]])[)
   {]b4_locations_if([[
@@ -189,7 +189,7 @@ m4_pushdef([b4_parse_param], m4_defn([b4_parse_param_orig]))dnl
 
 
   void
-  ]b4_parser_class[::yy_symbol_print_ (symbol_number_type yytype,
+  ]b4_parser_class[::yy_symbol_print_ (symbol_type_type yytype,
                            const semantic_type* yyvaluep]b4_locations_if([[,
                            const location_type* yylocationp]])[)
   {
@@ -325,14 +325,14 @@ b4_percent_code_get([[requires]])[
     /// \param yytype       The token type.
     /// \param yyvaluep     Its semantic value.]b4_locations_if([[
     /// \param yylocationp  Its location.]])[
-    virtual void yy_symbol_value_print_ (symbol_number_type yytype,
+    virtual void yy_symbol_value_print_ (symbol_type_type yytype,
                                          const semantic_type* yyvaluep]b4_locations_if([[,
                                          const location_type* yylocationp]])[);
     /// \brief Report a symbol on the debug stream.
     /// \param yytype       The token type.
     /// \param yyvaluep     Its semantic value.]b4_locations_if([[
     /// \param yylocationp  Its location.]])[
-    virtual void yy_symbol_print_ (symbol_number_type yytype,
+    virtual void yy_symbol_print_ (symbol_type_type yytype,
                                    const semantic_type* yyvaluep]b4_locations_if([[,
                                    const location_type* yylocationp]])[);
   private:
@@ -356,7 +356,7 @@ b4_percent_define_flag_if([[global_tokens_and_yystype]],
 
 ]b4_namespace_close[
 ]m4_define([b4_declare_symbol_enum],
-[[typedef ]b4_namespace_ref[::]b4_parser_class[::symbol_number_type yysymbol_type_t;
+[[typedef ]b4_namespace_ref[::]b4_parser_class[::symbol_type_type yysymbol_type_t;
 #define YYSYMBOL_YYEMPTY ]b4_namespace_ref[::]b4_parser_class[::YYSYMBOL_YYEMPTY
 #define YYSYMBOL_YYERROR ]b4_namespace_ref[::]b4_parser_class[::YYSYMBOL_YYERROR
 #define YYSYMBOL_YYEOF   ]b4_namespace_ref[::]b4_parser_class[::YYSYMBOL_YYEOF

--- a/data/skeletons/lalr1.cc
+++ b/data/skeletons/lalr1.cc
@@ -241,13 +241,13 @@ m4_define([b4_shared_declarations],
     public:
       context (const ]b4_parser_class[& yyparser, const symbol_type& yyla);
       const symbol_type& lookahead () const { return yyla_; }
-      symbol_number_type token () const { return yyla_.type_get (); }]b4_locations_if([[
+      symbol_type_type token () const { return yyla_.type_get (); }]b4_locations_if([[
       const location_type& location () const { return yyla_.location; }
 ]])[
       /// Put in YYARG at most YYARGN of the expected tokens, and return the
       /// number of tokens stored in YYARG.  If YYARG is null, return the
       /// number of expected tokens (guaranteed to be less than YYNTOKENS).
-      int yyexpected_tokens (symbol_number_type yyarg[], int yyargn) const;
+      int yyexpected_tokens (symbol_type_type yyarg[], int yyargn) const;
 
     private:
       const ]b4_parser_class[& yyparser_;
@@ -261,10 +261,10 @@ m4_define([b4_shared_declarations],
 
     /// Check the lookahead yytoken.
     /// \returns  true iff the token will be eventually shifted.
-    bool yy_lac_check_ (symbol_number_type yytoken) const;
+    bool yy_lac_check_ (symbol_type_type yytoken) const;
     /// Establish the initial context if no initial context currently exists.
     /// \returns  true iff the token will be eventually shifted.
-    bool yy_lac_establish_ (symbol_number_type yytoken);
+    bool yy_lac_establish_ (symbol_type_type yytoken);
     /// Discard any previous initial lookahead context because of event.
     /// \param event  the event which caused the lookahead to be discarded.
     ///               Only used for debbuging output.
@@ -280,7 +280,7 @@ m4_define([b4_shared_declarations],
       [detailed\|verbose], [[
     /// The arguments of the error message.
     int yysyntax_error_arguments_ (const context& yyctx,
-                                   symbol_number_type yyarg[], int yyargn) const;
+                                   symbol_type_type yyarg[], int yyargn) const;
 
     /// Generate an error message.
     /// \param yyctx     the context in which the error occurred.
@@ -304,11 +304,11 @@ m4_define([b4_shared_declarations],
     /// Convert a scanner token number \a t to a symbol number.
     /// In theory \a t should be a token_type, but character literals
     /// are valid, yet not members of the token_type enum.
-    static symbol_number_type yytranslate_ (int t);
+    static symbol_type_type yytranslate_ (int t);
 ]b4_parse_error_bmatch([custom\|detailed], [[
    /// The user-facing name of the symbol whose (internal) number is
    /// YYSYMBOL.  No bounds checking.
-   static const char *yysymbol_name (symbol_number_type yysymbol);
+   static const char *yysymbol_name (symbol_type_type yysymbol);
 ]])[
 
     // Tables.
@@ -378,7 +378,7 @@ m4_define([b4_shared_declarations],
 
       /// The (internal) type number (corresponding to \a state).
       /// \a YYSYMBOL_YYEMPTY when empty.
-      symbol_number_type type_get () const YY_NOEXCEPT;
+      symbol_type_type type_get () const YY_NOEXCEPT;
 
       /// The state number used to denote an empty symbol.
       /// We use the initial state, as it does not have a value.
@@ -586,7 +586,7 @@ m4_if(b4_prefix, [yy], [],
   /* The user-facing name of the symbol whose (internal) number is
      YYSYMBOL.  No bounds checking. */
   const char *
-  ]b4_parser_class[::yysymbol_name (symbol_number_type yysymbol)
+  ]b4_parser_class[::yysymbol_name (symbol_type_type yysymbol)
   {
     static const char *const yy_sname[] =
     {
@@ -696,13 +696,13 @@ b4_parse_error_case([verbose], [[
     : state (s)
   {}
 
-  ]b4_parser_class[::symbol_number_type
+  ]b4_parser_class[::symbol_type_type
   ]b4_parser_class[::by_state::type_get () const YY_NOEXCEPT
   {
     if (state == empty_state)
       return YYSYMBOL_YYEMPTY;
     else
-      return YY_CAST (symbol_number_type, yystos_[+state]);
+      return YY_CAST (symbol_type_type, yystos_[+state]);
   }
 
   ]b4_parser_class[::stack_symbol_type::stack_symbol_type ()
@@ -773,7 +773,7 @@ b4_parse_error_case([verbose], [[
   {
     std::ostream& yyoutput = yyo;
     YYUSE (yyoutput);
-    symbol_number_type yytype = yysym.type_get ();
+    symbol_type_type yytype = yysym.type_get ();
 #if defined __GNUC__ && ! defined __clang__ && ! defined __ICC && __GNUC__ * 100 + __GNUC_MINOR__ <= 408
     // Avoid a (spurious) G++ 4.8 warning about "array subscript is
     // below array bounds".
@@ -1229,7 +1229,7 @@ b4_dollar_popdef])[]dnl
   {}
 
   int
-  ]b4_parser_class[::context::yyexpected_tokens (symbol_number_type yyarg[], int yyargn) const
+  ]b4_parser_class[::context::yyexpected_tokens (symbol_type_type yyarg[], int yyargn) const
   {
     // Actual number of expected tokens
     int yycount = 0;
@@ -1243,7 +1243,7 @@ b4_dollar_popdef])[]dnl
 
     for (int yyx = 0; yyx < YYNTOKENS; ++yyx)
       {
-        symbol_number_type yysym = YY_CAST (symbol_number_type, yyx);
+        symbol_type_type yysym = YY_CAST (symbol_type_type, yyx);
         if (yysym != YYSYMBOL_YYERROR && yysym != YYSYMBOL_YYUNDEF
             && yyparser_.yy_lac_check_ (yysym))
           {
@@ -1274,7 +1274,7 @@ b4_dollar_popdef])[]dnl
               else if (yycount == yyargn)
                 return 0;
               else
-                yyarg[yycount++] = YY_CAST (symbol_number_type, yyx);
+                yyarg[yycount++] = YY_CAST (symbol_type_type, yyx);
             }
       }
 ]])[
@@ -1283,7 +1283,7 @@ b4_dollar_popdef])[]dnl
 
 ]])b4_lac_if([[
   bool
-  ]b4_parser_class[::yy_lac_check_ (symbol_number_type yytoken) const
+  ]b4_parser_class[::yy_lac_check_ (symbol_type_type yytoken) const
   {
     // Logically, the yylac_stack's lifetime is confined to this function.
     // Clear it, to get rid of potential left-overs from previous call.
@@ -1361,7 +1361,7 @@ b4_dollar_popdef])[]dnl
 
   // Establish the initial context if no initial context currently exists.
   bool
-  ]b4_parser_class[::yy_lac_establish_ (symbol_number_type yytoken)
+  ]b4_parser_class[::yy_lac_establish_ (symbol_type_type yytoken)
   {
     /* Establish the initial context for the current lookahead if no initial
        context is currently established.
@@ -1423,7 +1423,7 @@ b4_dollar_popdef])[]dnl
 
   int
   ]b4_parser_class[::yysyntax_error_arguments_ (const context& yyctx,
-                                                symbol_number_type yyarg[], int yyargn) const
+                                                symbol_type_type yyarg[], int yyargn) const
   {
     /* There are many possibilities here to consider:
        - If this state is a consistent state with a default action, then
@@ -1472,7 +1472,7 @@ b4_dollar_popdef])[]dnl
     // Its maximum.
     enum { YYARGS_MAX = 5 };
     // Arguments of yyformat.
-    symbol_number_type yyarg[YYARGS_MAX];
+    symbol_type_type yyarg[YYARGS_MAX];
     int yycount = yysyntax_error_arguments_ (yyctx, yyarg, YYARGS_MAX);
 
     char const* yyformat = YY_NULLPTR;

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -637,7 +637,7 @@ union yyalloc
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex.  */
-static const ]b4_int_type_for([b4_translate])[ yytranslate[] =
+static const yysymbol_type_t yytranslate[] =
 {
   ]b4_translate[
 };]])[
@@ -650,7 +650,7 @@ static const ]b4_int_type_for([b4_translate])[ yytranslate[] =
 #if ]b4_parse_error_case([simple], [b4_api_PREFIX[DEBUG || ]b4_token_table_flag], [[1]])[
 /* The user-facing name of the symbol whose (internal) number is
    YYSYMBOL.  No bounds checking.  */
-static const char *yysymbol_name (int yysymbol) YY_ATTRIBUTE_UNUSED;
+static const char *yysymbol_name (yysymbol_type_t yysymbol) YY_ATTRIBUTE_UNUSED;
 
 ]b4_parse_error_bmatch([simple\|verbose],
 [[/* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
@@ -661,12 +661,12 @@ static const char *const yytname[] =
 };
 
 static const char *
-yysymbol_name (int yysymbol)
+yysymbol_name (yysymbol_type_t yysymbol)
 {
   return yytname[yysymbol];
 }]],
 [[static const char *
-yysymbol_name (int yysymbol)
+yysymbol_name (yysymbol_type_t yysymbol)
 {
   static const char *const yy_sname[] =
   {
@@ -1013,7 +1013,7 @@ do {                                                                     \
    any old *YYES other than YYESA.  */
 static int
 yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
-        YYPTRDIFF_T *yyes_capacity, yy_state_t *yyssp, int yytoken)
+        YYPTRDIFF_T *yyes_capacity, yy_state_t *yyssp, yysymbol_type_t yytoken)
 {
   yy_state_t *yyes_prev = yyssp;
   yy_state_t *yyesp = yyes_prev;
@@ -1125,7 +1125,7 @@ typedef struct
   yy_state_t *yyesa;
   yy_state_t **yyes;
   YYPTRDIFF_T *yyes_capacity;]])])[
-  int yytoken;]b4_locations_if([[
+  yysymbol_type_t yytoken;]b4_locations_if([[
   YYLTYPE *yylloc;]])[
 } yyparse_context_t;
 
@@ -1137,10 +1137,10 @@ typedef struct
    YYARG up to YYARGN. */]b4_push_if([[
 static int
 yypstate_expected_tokens (yypstate *yyps,
-                          int yyarg[], int yyargn)]], [[
+                          yysymbol_type_t yyarg[], int yyargn)]], [[
 static int
 yyexpected_tokens (const yyparse_context_t *yyctx,
-                   int yyarg[], int yyargn)]])[
+                   yysymbol_type_t yyarg[], int yyargn)]])[
 {
   /* Actual size of YYARG. */
   int yycount = 0;
@@ -1193,7 +1193,7 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
 /* Similar to the previous function.  */
 static int
 yyexpected_tokens (const yyparse_context_t *yyctx,
-                   int yyarg[], int yyargn)
+                   yysymbol_type_t yyarg[], int yyargn)
 {
   return yypstate_expected_tokens (yyctx->yyps, yyarg, yyargn);
 }]])[
@@ -1202,10 +1202,10 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
 ]b4_parse_error_bmatch(
          [custom],
 [[/* The token type of the lookahead of this context.  */
-static int
+static yysymbol_type_t
 yyparse_context_token (const yyparse_context_t *yyctx) YY_ATTRIBUTE_UNUSED;
 
-static int
+static yysymbol_type_t
 yyparse_context_token (const yyparse_context_t *yyctx)
 {
   return yyctx->yytoken;
@@ -1316,7 +1316,7 @@ yytnamerr (char *yyres, const char *yystr)
 
 static int
 yysyntax_error_arguments (const yyparse_context_t *yyctx,
-                          int yyarg[], int yyargn)
+                          yysymbol_type_t yyarg[], int yyargn)
 {
   /* Actual size of YYARG. */
   int yycount = 0;
@@ -1383,7 +1383,7 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
   const char *yyformat = YY_NULLPTR;
   /* Arguments of yyformat: reported tokens (one for the "unexpected",
      one per "expected"). */
-  int yyarg[YYARGS_MAX];
+  yysymbol_type_t yyarg[YYARGS_MAX];
   /* Cumulated lengths of YYARG.  */
   YYPTRDIFF_T yysize = 0;
 
@@ -1576,7 +1576,7 @@ yyparse (]m4_ifset([b4_parse_param], [b4_formals(b4_parse_param)], [void])[)]])[
   /* The return value of yyparse.  */
   int yyresult;
   /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
+  yysymbol_type_t yytoken = 0;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;]b4_locations_if([[

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -398,6 +398,7 @@ m4_if(b4_api_prefix, [yy], [],
                                 [/* Use api.header.include to #include this header
    instead of duplicating it here.  */
 ])b4_shared_declarations])[
+]b4_declare_symbol_enum[
 
 ]b4_user_post_prologue[
 ]b4_percent_code_get[]dnl
@@ -624,7 +625,6 @@ union yyalloc
 /* YYNSTATES -- Number of states.  */
 #define YYNSTATES  ]b4_states_number[
 
-#define YYUNDEFTOK  ]b4_undef_token_number[
 #define YYMAXUTOK   ]b4_user_token_number_max[
 
 
@@ -633,7 +633,7 @@ union yyalloc
 ]b4_api_token_raw_if(dnl
 [[#define YYTRANSLATE(YYX) (YYX)]],
 [[#define YYTRANSLATE(YYX)                                                \
-  (0 <= (YYX) && (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex.  */
@@ -738,8 +738,6 @@ enum { YYNOMEM = -2 };
       }                                                           \
   while (0)
 
-/* Error symbol internal number. */
-#define YYTERROR        1
 /* Error token external number. */
 #define YYERRCODE       ]b4_symbol(1, user_number)[
 
@@ -1021,7 +1019,7 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
   yy_state_t *yyesp = yyes_prev;
   /* Reduce until we encounter a shift and thereby accept the token.  */
   YYDPRINTF ((stderr, "LAC: checking lookahead %s:", yysymbol_name (yytoken)));
-  if (yytoken == YYUNDEFTOK)
+  if (yytoken == YYSYMBOL_YYUNDEF)
     {
       YYDPRINTF ((stderr, " Always Err\n"));
       return 1;
@@ -1149,7 +1147,7 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
 ]b4_lac_if([[
   int yyx;
   for (yyx = 0; yyx < YYNTOKENS; ++yyx)
-    if (yyx != YYTERROR && yyx != YYUNDEFTOK)
+    if (yyx != YYSYMBOL_error && yyx != YYSYMBOL_YYUNDEF)
       switch (yy_lac (]b4_push_if([[yyps->yyesa, &yyps->yyes, &yyps->yyes_capacity, yyps->yyssp, yyx]],
                                   [[yyctx->yyesa, yyctx->yyes, yyctx->yyes_capacity, yyctx->yyssp, yyx]])[))
         {
@@ -1177,7 +1175,7 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
       int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
       int yyx;
       for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-        if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
+        if (yycheck[yyx + yyn] == yyx && yyx != YYSYMBOL_error
             && !yytable_value_is_error (yytable[yyx + yyn]))
           {
             if (!yyarg)
@@ -1729,7 +1727,7 @@ yybackup:
 
   /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
   if (yychar == YYEMPTY)
     {]b4_push_if([[
       if (!yyps->yynew)
@@ -1757,7 +1755,8 @@ yyread_pushed_token:]])[
 
   if (yychar <= YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
     }
   else
@@ -1999,8 +1998,8 @@ yyerrlab1:
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
         {
-          yyn += YYTERROR;
-          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+          yyn += YYSYMBOL_error;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_error)
             {
               yyn = yytable[yyn];
               if (0 < yyn)

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -1147,7 +1147,7 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
 ]b4_lac_if([[
   int yyx;
   for (yyx = 0; yyx < YYNTOKENS; ++yyx)
-    if (yyx != YYSYMBOL_error && yyx != YYSYMBOL_YYUNDEF)
+    if (yyx != YYSYMBOL_YYERROR && yyx != YYSYMBOL_YYUNDEF)
       switch (yy_lac (]b4_push_if([[yyps->yyesa, &yyps->yyes, &yyps->yyes_capacity, yyps->yyssp, yyx]],
                                   [[yyctx->yyesa, yyctx->yyes, yyctx->yyes_capacity, yyctx->yyssp, yyx]])[))
         {
@@ -1175,7 +1175,7 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
       int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
       int yyx;
       for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-        if (yycheck[yyx + yyn] == yyx && yyx != YYSYMBOL_error
+        if (yycheck[yyx + yyn] == yyx && yyx != YYSYMBOL_YYERROR
             && !yytable_value_is_error (yytable[yyx + yyn]))
           {
             if (!yyarg)
@@ -1998,8 +1998,8 @@ yyerrlab1:
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
         {
-          yyn += YYSYMBOL_error;
-          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_error)
+          yyn += YYSYMBOL_YYERROR;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYERROR)
             {
               yyn = yytable[yyn];
               if (0 < yyn)

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -631,13 +631,15 @@ union yyalloc
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex, with out-of-bounds checking.  */
 ]b4_api_token_raw_if(dnl
-[[#define YYTRANSLATE(YYX) (YYX)]],
-[[#define YYTRANSLATE(YYX)                                                \
-  (0 <= (YYX) && (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYSYMBOL_YYUNDEF)
+[[#define YYTRANSLATE(YYX) YY_CAST (yysymbol_type_t, YYX)]],
+[[#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_type_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex.  */
-static const yysymbol_type_t yytranslate[] =
+static const ]b4_int_type_for([b4_translate])[ yytranslate[] =
 {
   ]b4_translate[
 };]])[

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -1149,22 +1149,25 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
 ]b4_lac_if([[
   int yyx;
   for (yyx = 0; yyx < YYNTOKENS; ++yyx)
-    if (yyx != YYSYMBOL_YYERROR && yyx != YYSYMBOL_YYUNDEF)
-      switch (yy_lac (]b4_push_if([[yyps->yyesa, &yyps->yyes, &yyps->yyes_capacity, yyps->yyssp, yyx]],
-                                  [[yyctx->yyesa, yyctx->yyes, yyctx->yyes_capacity, yyctx->yyssp, yyx]])[))
-        {
-        case YYNOMEM:
-          return YYNOMEM;
-        case 1:
-          continue;
-        default:
-          if (!yyarg)
-            ++yycount;
-          else if (yycount == yyargn)
-            return 0;
-          else
-            yyarg[yycount++] = yyx;
-        }]],
+    {
+      yysymbol_type_t yysym = YY_CAST (yysymbol_type_t, yyx);
+      if (yysym != YYSYMBOL_YYERROR && yysym != YYSYMBOL_YYUNDEF)
+        switch (yy_lac (]b4_push_if([[yyps->yyesa, &yyps->yyes, &yyps->yyes_capacity, yyps->yyssp, yysym]],
+                                    [[yyctx->yyesa, yyctx->yyes, yyctx->yyes_capacity, yyctx->yyssp, yysym]])[))
+          {
+          case YYNOMEM:
+            return YYNOMEM;
+          case 1:
+            continue;
+          default:
+            if (!yyarg)
+              ++yycount;
+            else if (yycount == yyargn)
+              return 0;
+            else
+              yyarg[yycount++] = yysym;
+          }
+    }]],
 [[  int yyn = yypact@{+*]b4_push_if([yyps], [yyctx])[->yyssp@};
   if (!yypact_value_is_default (yyn))
     {
@@ -1185,7 +1188,7 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
             else if (yycount == yyargn)
               return 0;
             else
-              yyarg[yycount++] = yyx;
+              yyarg[yycount++] = YY_CAST (yysymbol_type_t, yyx);
           }
     }]])[
   return yycount;

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -1348,7 +1348,7 @@ yysyntax_error_arguments (const yyparse_context_t *yyctx,
        one exception: it will still contain any token that will not be
        accepted due to an error action in a later state.]])[
   */
-  if (yyctx->yytoken != YYEMPTY)
+  if (yyctx->yytoken != YYSYMBOL_YYEMPTY)
     {
       int yyn;]b4_lac_if([[
       YYDPRINTF ((stderr, "Constructing syntax error message\n"));]])[
@@ -1576,7 +1576,7 @@ yyparse (]m4_ifset([b4_parse_param], [b4_formals(b4_parse_param)], [void])[)]])[
   /* The return value of yyparse.  */
   int yyresult;
   /* Lookahead token as an internal (translated) token number.  */
-  yysymbol_type_t yytoken = 0;
+  yysymbol_type_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;]b4_locations_if([[
@@ -1889,7 +1889,7 @@ yyreduce:
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
-  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
+  yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
 
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -649,6 +649,9 @@ static const ]b4_int_type_for([b4_translate])[ yytranslate[] =
      [[YYRLINE[YYN] -- Source line where rule number YYN was defined.]])[
 #endif
 
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_type_t, yystos[State])
+
 #if ]b4_parse_error_case([simple], [b4_api_PREFIX[DEBUG || ]b4_token_table_flag], [[1]])[
 /* The user-facing name of the symbol whose (internal) number is
    YYSYMBOL.  No bounds checking.  */
@@ -819,7 +822,7 @@ yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp,]b4_locations_if([[ YYLTYPE *
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
-                       yystos[+yyssp[yyi + 1 - yynrhs]],
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
                        &]b4_rhs_value(yynrhs, yyi + 1)[
                        ]b4_locations_if([, &]b4_rhs_location(yynrhs, yyi + 1))[]dnl
                        b4_user_args[);
@@ -1866,7 +1869,7 @@ yyreduce:
      case of YYERROR or YYBACKUP, subsequent parser actions might lead
      to an incorrect destructor call or verbose syntax error message
      before the lookahead is translated.  */
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_type_t, yyr1[yyn]), &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
   yylen = 0;
@@ -2018,7 +2021,7 @@ yyerrlab1:
 
 ]b4_locations_if([[      yyerror_range[1] = *yylsp;]])[
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp]b4_locations_if([, yylsp])[]b4_user_args[);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp]b4_locations_if([, yylsp])[]b4_user_args[);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -2039,7 +2042,7 @@ yyerrlab1:
   *++yylsp = yyloc;]])[
 
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -2091,7 +2094,7 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[+*yyssp], yyvsp]b4_locations_if([, yylsp])[]b4_user_args[);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp]b4_locations_if([, yylsp])[]b4_user_args[);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow

--- a/examples/c/bistromathic/parse.y
+++ b/examples/c/bistromathic/parse.y
@@ -289,7 +289,7 @@ yyreport_syntax_error (const yyparse_context_t *ctx)
   fprintf (stderr, ": syntax error");
   {
     enum { TOKENMAX = 10 };
-    int expected[TOKENMAX];
+    yysymbol_type_t expected[TOKENMAX];
     int n = yyexpected_tokens (ctx, expected, TOKENMAX);
     if (n < 0)
       // Forward errors to yyparse.
@@ -300,7 +300,7 @@ yyreport_syntax_error (const yyparse_context_t *ctx)
                  i == 0 ? ": expected" : " or", yysymbol_name (expected[i]));
   }
   {
-    int lookahead = yyparse_context_token (ctx);
+    yysymbol_type_t lookahead = yyparse_context_token (ctx);
     if (lookahead != YYEMPTY)
       fprintf (stderr, " before %s", yysymbol_name (lookahead));
   }

--- a/examples/c/bistromathic/parse.y
+++ b/examples/c/bistromathic/parse.y
@@ -386,23 +386,25 @@ completion (const char *text, int start, int end)
   char **matches = calloc (ntokens + symbol_count () + 2, sizeof *matches);
   int match = 1;
   for (int i = 0; i < ntokens; ++i)
-    if (tokens[i] == YYTRANSLATE (TOK_VAR))
+    switch (tokens[i])
       {
-        for (symrec *s = sym_table; s; s = s->next)
-          if (s->type == TOK_VAR && strncmp (text, s->name, len) == 0)
-            matches[match++] = strdup (s->name);
-      }
-    else if (tokens[i] == YYTRANSLATE (TOK_FUN))
-      {
+      case YYSYMBOL_FUN:
         for (symrec *s = sym_table; s; s = s->next)
           if (s->type == TOK_FUN && strncmp (text, s->name, len) == 0)
             matches[match++] = strdup (s->name);
-      }
-    else
-      {
-        const char* token = yysymbol_name (tokens[i]);
-        if (strncmp (token, text, strlen (text)) == 0)
-          matches[match++] = strdup (token);
+        break;
+      case YYSYMBOL_VAR:
+        for (symrec *s = sym_table; s; s = s->next)
+          if (s->type == TOK_VAR && strncmp (text, s->name, len) == 0)
+            matches[match++] = strdup (s->name);
+        break;
+      default:
+        {
+          const char* token = yysymbol_name (tokens[i]);
+          if (strncmp (text, token, len) == 0)
+            matches[match++] = strdup (token);
+          break;
+        }
       }
 
   // Find the longest common prefix, and install it in matches[0], as

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -608,7 +608,7 @@ union yyalloc
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex, with out-of-bounds checking.  */
-#define YYTRANSLATE(YYX) (YYX)
+#define YYTRANSLATE(YYX) YY_CAST (yysymbol_type_t, YYX)
 
 #if GRAM_DEBUG
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -105,7 +105,7 @@ enum yysymbol_type_t
 {
   YYSYMBOL_YYEMPTY = -2,
   YYSYMBOL_YYEOF = 0,
-  YYSYMBOL_error = 1,
+  YYSYMBOL_YYERROR = 1,
   YYSYMBOL_YYUNDEF = 2,
   YYSYMBOL_STRING = 3,
   YYSYMBOL_TSTRING = 4,
@@ -1594,7 +1594,7 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
 
   int yyx;
   for (yyx = 0; yyx < YYNTOKENS; ++yyx)
-    if (yyx != YYSYMBOL_error && yyx != YYSYMBOL_YYUNDEF)
+    if (yyx != YYSYMBOL_YYERROR && yyx != YYSYMBOL_YYUNDEF)
       switch (yy_lac (yyctx->yyesa, yyctx->yyes, yyctx->yyes_capacity, yyctx->yyssp, yyx))
         {
         case YYNOMEM:
@@ -2676,8 +2676,8 @@ yyerrlab1:
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
         {
-          yyn += YYSYMBOL_error;
-          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_error)
+          yyn += YYSYMBOL_YYERROR;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYERROR)
             {
               yyn = yytable[yyn];
               if (0 < yyn)

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -103,6 +103,7 @@
 /* Symbol type.  */
 enum yysymbol_type_t
 {
+  YYSYMBOL_YYEMPTY = -2,
   YYSYMBOL_YYEOF = 0,
   YYSYMBOL_error = 1,
   YYSYMBOL_YYUNDEF = 2,
@@ -620,10 +621,10 @@ static const yytype_int16 yyrline[] =
 #if 1
 /* The user-facing name of the symbol whose (internal) number is
    YYSYMBOL.  No bounds checking.  */
-static const char *yysymbol_name (int yysymbol) YY_ATTRIBUTE_UNUSED;
+static const char *yysymbol_name (yysymbol_type_t yysymbol) YY_ATTRIBUTE_UNUSED;
 
 static const char *
-yysymbol_name (int yysymbol)
+yysymbol_name (yysymbol_type_t yysymbol)
 {
   static const char *const yy_sname[] =
   {
@@ -1464,7 +1465,7 @@ do {                                                                     \
    any old *YYES other than YYESA.  */
 static int
 yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
-        YYPTRDIFF_T *yyes_capacity, yy_state_t *yyssp, int yytoken)
+        YYPTRDIFF_T *yyes_capacity, yy_state_t *yyssp, yysymbol_type_t yytoken)
 {
   yy_state_t *yyes_prev = yyssp;
   yy_state_t *yyesp = yyes_prev;
@@ -1574,7 +1575,7 @@ typedef struct
   yy_state_t *yyesa;
   yy_state_t **yyes;
   YYPTRDIFF_T *yyes_capacity;
-  int yytoken;
+  yysymbol_type_t yytoken;
   YYLTYPE *yylloc;
 } yyparse_context_t;
 
@@ -1586,7 +1587,7 @@ typedef struct
    YYARG up to YYARGN. */
 static int
 yyexpected_tokens (const yyparse_context_t *yyctx,
-                   int yyarg[], int yyargn)
+                   yysymbol_type_t yyarg[], int yyargn)
 {
   /* Actual size of YYARG. */
   int yycount = 0;
@@ -1615,10 +1616,10 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
 
 
 /* The token type of the lookahead of this context.  */
-static int
+static yysymbol_type_t
 yyparse_context_token (const yyparse_context_t *yyctx) YY_ATTRIBUTE_UNUSED;
 
-static int
+static yysymbol_type_t
 yyparse_context_token (const yyparse_context_t *yyctx)
 {
   return yyctx->yytoken;
@@ -1770,7 +1771,7 @@ YYLTYPE yylloc = yyloc_default;
   /* The return value of yyparse.  */
   int yyresult;
   /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
+  yysymbol_type_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
@@ -2604,7 +2605,7 @@ yyreduce:
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
-  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
+  yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
 
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
@@ -2787,11 +2788,11 @@ yyreport_syntax_error (const yyparse_context_t *ctx)
   enum { ARGS_MAX = 5 };
   const char *argv[ARGS_MAX];
   int argc = 0;
-  int unexpected = yyparse_context_token (ctx);
-  if (unexpected != YYEMPTY)
+  yysymbol_type_t unexpected = yyparse_context_token (ctx);
+  if (unexpected != YYSYMBOL_YYEMPTY)
     {
       argv[argc++] = yysymbol_name (unexpected);
-      int expected[ARGS_MAX - 1];
+      yysymbol_type_t expected[ARGS_MAX - 1];
       int nexpected = yyexpected_tokens (ctx, expected, ARGS_MAX - 1);
       if (nexpected < 0)
         res = nexpected;

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -100,6 +100,103 @@
 # endif
 
 #include "src/parse-gram.h"
+/* Symbol type.  */
+enum yysymbol_type_t
+{
+  YYSYMBOL_YYEOF = 0,
+  YYSYMBOL_error = 1,
+  YYSYMBOL_YYUNDEF = 2,
+  YYSYMBOL_STRING = 3,
+  YYSYMBOL_TSTRING = 4,
+  YYSYMBOL_PERCENT_TOKEN = 5,
+  YYSYMBOL_PERCENT_NTERM = 6,
+  YYSYMBOL_PERCENT_TYPE = 7,
+  YYSYMBOL_PERCENT_DESTRUCTOR = 8,
+  YYSYMBOL_PERCENT_PRINTER = 9,
+  YYSYMBOL_PERCENT_LEFT = 10,
+  YYSYMBOL_PERCENT_RIGHT = 11,
+  YYSYMBOL_PERCENT_NONASSOC = 12,
+  YYSYMBOL_PERCENT_PRECEDENCE = 13,
+  YYSYMBOL_PERCENT_PREC = 14,
+  YYSYMBOL_PERCENT_DPREC = 15,
+  YYSYMBOL_PERCENT_MERGE = 16,
+  YYSYMBOL_PERCENT_CODE = 17,
+  YYSYMBOL_PERCENT_DEFAULT_PREC = 18,
+  YYSYMBOL_PERCENT_DEFINE = 19,
+  YYSYMBOL_PERCENT_DEFINES = 20,
+  YYSYMBOL_PERCENT_ERROR_VERBOSE = 21,
+  YYSYMBOL_PERCENT_EXPECT = 22,
+  YYSYMBOL_PERCENT_EXPECT_RR = 23,
+  YYSYMBOL_PERCENT_FLAG = 24,
+  YYSYMBOL_PERCENT_FILE_PREFIX = 25,
+  YYSYMBOL_PERCENT_GLR_PARSER = 26,
+  YYSYMBOL_PERCENT_INITIAL_ACTION = 27,
+  YYSYMBOL_PERCENT_LANGUAGE = 28,
+  YYSYMBOL_PERCENT_NAME_PREFIX = 29,
+  YYSYMBOL_PERCENT_NO_DEFAULT_PREC = 30,
+  YYSYMBOL_PERCENT_NO_LINES = 31,
+  YYSYMBOL_PERCENT_NONDETERMINISTIC_PARSER = 32,
+  YYSYMBOL_PERCENT_OUTPUT = 33,
+  YYSYMBOL_PERCENT_PURE_PARSER = 34,
+  YYSYMBOL_PERCENT_REQUIRE = 35,
+  YYSYMBOL_PERCENT_SKELETON = 36,
+  YYSYMBOL_PERCENT_START = 37,
+  YYSYMBOL_PERCENT_TOKEN_TABLE = 38,
+  YYSYMBOL_PERCENT_VERBOSE = 39,
+  YYSYMBOL_PERCENT_YACC = 40,
+  YYSYMBOL_BRACED_CODE = 41,
+  YYSYMBOL_BRACED_PREDICATE = 42,
+  YYSYMBOL_BRACKETED_ID = 43,
+  YYSYMBOL_CHAR = 44,
+  YYSYMBOL_COLON = 45,
+  YYSYMBOL_EPILOGUE = 46,
+  YYSYMBOL_EQUAL = 47,
+  YYSYMBOL_ID = 48,
+  YYSYMBOL_ID_COLON = 49,
+  YYSYMBOL_PERCENT_PERCENT = 50,
+  YYSYMBOL_PIPE = 51,
+  YYSYMBOL_PROLOGUE = 52,
+  YYSYMBOL_SEMICOLON = 53,
+  YYSYMBOL_TAG = 54,
+  YYSYMBOL_TAG_ANY = 55,
+  YYSYMBOL_TAG_NONE = 56,
+  YYSYMBOL_INT = 57,
+  YYSYMBOL_PERCENT_PARAM = 58,
+  YYSYMBOL_PERCENT_UNION = 59,
+  YYSYMBOL_PERCENT_EMPTY = 60,
+  YYSYMBOL_YYACCEPT = 61,
+  YYSYMBOL_input = 62,
+  YYSYMBOL_prologue_declarations = 63,
+  YYSYMBOL_prologue_declaration = 64,
+  YYSYMBOL_params = 66,
+  YYSYMBOL_grammar_declaration = 67,
+  YYSYMBOL_code_props_type = 68,
+  YYSYMBOL_union_name = 69,
+  YYSYMBOL_symbol_declaration = 70,
+  YYSYMBOL_precedence_declarator = 73,
+  YYSYMBOL_generic_symlist = 75,
+  YYSYMBOL_generic_symlist_item = 76,
+  YYSYMBOL_tag = 77,
+  YYSYMBOL_nterm_decls = 78,
+  YYSYMBOL_token_decls = 79,
+  YYSYMBOL_token_decl = 81,
+  YYSYMBOL_alias = 83,
+  YYSYMBOL_token_decls_for_prec = 84,
+  YYSYMBOL_token_decl_for_prec = 86,
+  YYSYMBOL_symbol_decls = 87,
+  YYSYMBOL_grammar = 89,
+  YYSYMBOL_rules_or_grammar_declaration = 90,
+  YYSYMBOL_rules = 91,
+  YYSYMBOL_rhs = 94,
+  YYSYMBOL_variable = 96,
+  YYSYMBOL_value = 97,
+  YYSYMBOL_id = 98,
+  YYSYMBOL_id_colon = 99,
+  YYSYMBOL_symbol = 100,
+  YYSYMBOL_string_as_id = 101
+};
+typedef enum yysymbol_type_t yysymbol_type_t;
+
 
 
 /* Unqualified %code blocks.  */
@@ -493,7 +590,6 @@ union yyalloc
 /* YYNSTATES -- Number of states.  */
 #define YYNSTATES  167
 
-#define YYUNDEFTOK  2
 #define YYMAXUTOK   315
 
 
@@ -815,8 +911,6 @@ enum { YYNOMEM = -2 };
       }                                                           \
   while (0)
 
-/* Error symbol internal number. */
-#define YYTERROR        1
 /* Error token external number. */
 #define YYERRCODE       256
 
@@ -1376,7 +1470,7 @@ yy_lac (yy_state_t *yyesa, yy_state_t **yyes,
   yy_state_t *yyesp = yyes_prev;
   /* Reduce until we encounter a shift and thereby accept the token.  */
   YYDPRINTF ((stderr, "LAC: checking lookahead %s:", yysymbol_name (yytoken)));
-  if (yytoken == YYUNDEFTOK)
+  if (yytoken == YYSYMBOL_YYUNDEF)
     {
       YYDPRINTF ((stderr, " Always Err\n"));
       return 1;
@@ -1499,7 +1593,7 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
 
   int yyx;
   for (yyx = 0; yyx < YYNTOKENS; ++yyx)
-    if (yyx != YYTERROR && yyx != YYUNDEFTOK)
+    if (yyx != YYSYMBOL_error && yyx != YYSYMBOL_YYUNDEF)
       switch (yy_lac (yyctx->yyesa, yyctx->yyes, yyctx->yyes_capacity, yyctx->yyssp, yyx))
         {
         case YYNOMEM:
@@ -1833,7 +1927,7 @@ yybackup:
 
   /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
   if (yychar == YYEMPTY)
     {
       YYDPRINTF ((stderr, "Reading a token\n"));
@@ -1842,7 +1936,8 @@ yybackup:
 
   if (yychar <= YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
     }
   else
@@ -2580,8 +2675,8 @@ yyerrlab1:
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
         {
-          yyn += YYTERROR;
-          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+          yyn += YYSYMBOL_error;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_error)
             {
               yyn = yytable[yyn];
               if (0 < yyn)

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.5.3.  */
+/* A Bison parser, made by GNU Bison 3.5.3.219-2a6f.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
@@ -48,7 +48,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.5.3"
+#define YYBISON_VERSION "3.5.3.219-2a6f"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -169,32 +169,44 @@ enum yysymbol_type_t
   YYSYMBOL_input = 62,
   YYSYMBOL_prologue_declarations = 63,
   YYSYMBOL_prologue_declaration = 64,
+  YYSYMBOL_65____1 = 65,
   YYSYMBOL_params = 66,
   YYSYMBOL_grammar_declaration = 67,
   YYSYMBOL_code_props_type = 68,
   YYSYMBOL_union_name = 69,
   YYSYMBOL_symbol_declaration = 70,
+  YYSYMBOL_71____2 = 71,
+  YYSYMBOL_72____3 = 72,
   YYSYMBOL_precedence_declarator = 73,
+  YYSYMBOL_74_tag_opt = 74,
   YYSYMBOL_generic_symlist = 75,
   YYSYMBOL_generic_symlist_item = 76,
   YYSYMBOL_tag = 77,
   YYSYMBOL_nterm_decls = 78,
   YYSYMBOL_token_decls = 79,
+  YYSYMBOL_80_token_decl_1 = 80,
   YYSYMBOL_token_decl = 81,
+  YYSYMBOL_82_int_opt = 82,
   YYSYMBOL_alias = 83,
   YYSYMBOL_token_decls_for_prec = 84,
+  YYSYMBOL_85_token_decl_for_prec_1 = 85,
   YYSYMBOL_token_decl_for_prec = 86,
   YYSYMBOL_symbol_decls = 87,
+  YYSYMBOL_88_symbol_decl_1 = 88,
   YYSYMBOL_grammar = 89,
   YYSYMBOL_rules_or_grammar_declaration = 90,
   YYSYMBOL_rules = 91,
+  YYSYMBOL_92____4 = 92,
+  YYSYMBOL_93_rhses_1 = 93,
   YYSYMBOL_rhs = 94,
+  YYSYMBOL_95_named_ref_opt = 95,
   YYSYMBOL_variable = 96,
   YYSYMBOL_value = 97,
   YYSYMBOL_id = 98,
   YYSYMBOL_id_colon = 99,
   YYSYMBOL_symbol = 100,
-  YYSYMBOL_string_as_id = 101
+  YYSYMBOL_string_as_id = 101,
+  YYSYMBOL_102_epilogue_opt = 102
 };
 typedef enum yysymbol_type_t yysymbol_type_t;
 

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -1606,21 +1606,24 @@ yyexpected_tokens (const yyparse_context_t *yyctx,
 
   int yyx;
   for (yyx = 0; yyx < YYNTOKENS; ++yyx)
-    if (yyx != YYSYMBOL_YYERROR && yyx != YYSYMBOL_YYUNDEF)
-      switch (yy_lac (yyctx->yyesa, yyctx->yyes, yyctx->yyes_capacity, yyctx->yyssp, yyx))
-        {
-        case YYNOMEM:
-          return YYNOMEM;
-        case 1:
-          continue;
-        default:
-          if (!yyarg)
-            ++yycount;
-          else if (yycount == yyargn)
-            return 0;
-          else
-            yyarg[yycount++] = yyx;
-        }
+    {
+      yysymbol_type_t yysym = YY_CAST (yysymbol_type_t, yyx);
+      if (yysym != YYSYMBOL_YYERROR && yysym != YYSYMBOL_YYUNDEF)
+        switch (yy_lac (yyctx->yyesa, yyctx->yyes, yyctx->yyes_capacity, yyctx->yyssp, yysym))
+          {
+          case YYNOMEM:
+            return YYNOMEM;
+          case 1:
+            continue;
+          default:
+            if (!yyarg)
+              ++yycount;
+            else if (yycount == yyargn)
+              return 0;
+            else
+              yyarg[yycount++] = yysym;
+          }
+    }
   return yycount;
 }
 

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -630,6 +630,9 @@ static const yytype_int16 yyrline[] =
 };
 #endif
 
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_type_t, yystos[State])
+
 #if 1
 /* The user-facing name of the symbol whose (internal) number is
    YYSYMBOL.  No bounds checking.  */
@@ -1032,7 +1035,7 @@ do {                                                                      \
 
 static void
 yy_symbol_value_print (FILE *yyo,
-                       int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
+                       yysymbol_type_t yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
 {
   FILE *yyoutput = yyo;
   YYUSE (yyoutput);
@@ -1243,7 +1246,7 @@ troff (yyo);
 
 static void
 yy_symbol_print (FILE *yyo,
-                 int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
+                 yysymbol_type_t yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
 {
   YYFPRINTF (yyo, "%s %s (",
              yytype < YYNTOKENS ? "token" : "nterm", yysymbol_name (yytype));
@@ -1296,7 +1299,7 @@ yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp,
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
-                       yystos[+yyssp[yyi + 1 - yynrhs]],
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
                        &yyvsp[(yyi + 1) - (yynrhs)]
                        , &(yylsp[(yyi + 1) - (yynrhs)])                       );
       YYFPRINTF (stderr, "\n");
@@ -1660,7 +1663,7 @@ yyreport_syntax_error (const yyparse_context_t *yyctx);
 
 static void
 yydestruct (const char *yymsg,
-            int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp)
+            yysymbol_type_t yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp)
 {
   YYUSE (yyvaluep);
   YYUSE (yylocationp);
@@ -2592,7 +2595,7 @@ yyreduce:
      case of YYERROR or YYBACKUP, subsequent parser actions might lead
      to an incorrect destructor call or verbose syntax error message
      before the lookahead is translated.  */
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_type_t, yyr1[yyn]), &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
   yylen = 0;
@@ -2706,7 +2709,7 @@ yyerrlab1:
 
       yyerror_range[1] = *yylsp;
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp, yylsp);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, yylsp);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -2727,7 +2730,7 @@ yyerrlab1:
   *++yylsp = yyloc;
 
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -2779,7 +2782,7 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[+*yyssp], yyvsp, yylsp);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, yylsp);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow

--- a/src/parse-gram.h
+++ b/src/parse-gram.h
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.5.3.  */
+/* A Bison parser, made by GNU Bison 3.5.3.219-2a6f.  */
 
 /* Bison interface for Yacc-like parsers in C
 

--- a/src/parse-gram.y
+++ b/src/parse-gram.y
@@ -807,11 +807,11 @@ yyreport_syntax_error (const yyparse_context_t *ctx)
   enum { ARGS_MAX = 5 };
   const char *argv[ARGS_MAX];
   int argc = 0;
-  int unexpected = yyparse_context_token (ctx);
+  yysymbol_type_t unexpected = yyparse_context_token (ctx);
   if (unexpected != YYEMPTY)
     {
       argv[argc++] = yysymbol_name (unexpected);
-      int expected[ARGS_MAX - 1];
+      yysymbol_type_t expected[ARGS_MAX - 1];
       int nexpected = yyexpected_tokens (ctx, expected, ARGS_MAX - 1);
       if (nexpected < 0)
         res = nexpected;

--- a/src/parse-gram.y
+++ b/src/parse-gram.y
@@ -808,7 +808,7 @@ yyreport_syntax_error (const yyparse_context_t *ctx)
   const char *argv[ARGS_MAX];
   int argc = 0;
   yysymbol_type_t unexpected = yyparse_context_token (ctx);
-  if (unexpected != YYEMPTY)
+  if (unexpected != YYSYMBOL_YYEMPTY)
     {
       argv[argc++] = yysymbol_name (unexpected);
       yysymbol_type_t expected[ARGS_MAX - 1];

--- a/tests/headers.at
+++ b/tests/headers.at
@@ -319,7 +319,9 @@ AT_PERL_CHECK([[-n -0777 -e '
   s{//.*}{}g;
   s{\b((defined|if)\ YYDEBUG
       |YYChar
+      |YYNTOKENS  # This is actual scoped in a C++ class.
       |YYPUSH_MORE(?:_DEFINED)?
+      |YYSYMBOL_(\w+)  # These guys are scoped.
       |YYUSE
       |YY_ATTRIBUTE(?:_PURE|_UNUSED)
       |YY(?:_REINTERPRET)?_CAST

--- a/tests/local.at
+++ b/tests/local.at
@@ -633,13 +633,13 @@ yyreport_syntax_error (const yyparse_context_t *ctx]AT_PARAM_IF([, AT_PARSE_PARA
   fprintf (stderr, ": ");]])[
   fprintf (stderr, "syntax error");
   {
-    int la = yyparse_context_token (ctx);
+    yysymbol_type_t la = yyparse_context_token (ctx);
     if (la != YYEMPTY)
       fprintf (stderr, " on token [%s]", yysymbol_name (la));
   }
   {
     enum { TOKENMAX = 10 };
-    int expected[TOKENMAX];
+    yysymbol_type_t expected[TOKENMAX];
     int n = yyexpected_tokens (ctx, expected, TOKENMAX);
     /* Forward errors to yyparse.  */
     if (n < 0)

--- a/tests/local.at
+++ b/tests/local.at
@@ -749,13 +749,13 @@ void
   std::cerr << ctx.location () << ": ";]])[
   std::cerr << "syntax error";
   {
-    int la = ctx.token ();
-    if (la != empty_symbol)
+    symbol_type_type la = ctx.token ();
+    if (la != YYSYMBOL_YYEMPTY)
       fprintf (stderr, " on token [%s]", yysymbol_name (la));
   }
   {
     enum { TOKENMAX = 10 };
-    int expected[TOKENMAX];
+    symbol_type_type expected[TOKENMAX];
     int n = ctx.yyexpected_tokens (expected, TOKENMAX);
     if (0 < n)
       {

--- a/tests/regression.at
+++ b/tests/regression.at
@@ -665,7 +665,7 @@ AT_BISON_CHECK([-v -o input.c input.y])
 [sed -n 's/  *$//;/^static const.*\[\] =/,/^}/p' input.c >tables.c]
 
 AT_CHECK([[cat tables.c]], 0,
-[[static const yysymbol_type_t yytranslate[] =
+[[static const yytype_int8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,

--- a/tests/regression.at
+++ b/tests/regression.at
@@ -665,7 +665,7 @@ AT_BISON_CHECK([-v -o input.c input.y])
 [sed -n 's/  *$//;/^static const.*\[\] =/,/^}/p' input.c >tables.c]
 
 AT_CHECK([[cat tables.c]], 0,
-[[static const yytype_int8 yytranslate[] =
+[[static const yysymbol_type_t yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,


### PR DESCRIPTION
There are many advantages in exposing the symbol (internal) numbers:

- custom error messages can use them to decide how to represent a given symbol, or a set of symbols.  See my message about custom error messages for examples. (https://lists.gnu.org/archive/html/bison-patches/2020-01/msg00000.html)

- we need something similar in uses of `yyexpected_tokens`.  For instance, currently, bistromathic's `completion()` reads:

``` c
int ntokens = expected_tokens (line, tokens, YYNTOKENS);
[...]
for (int i = 0; i < ntokens; ++i)
  if (tokens[i] == YYTRANSLATE (TOK_VAR))
  [...]
  else if (tokens[i] == YYTRANSLATE (TOK_FUN))
  [...]
  else
  [...]
```

- now that's it's a compile-time expression, we can easily build static tables, use switch, etc.

- some users depended on the ability to get the token number from a symbol to write test cases for their scanners.  But Bison 3.5 removed the table this feature depended upon (a reverse `yytranslate`).  Now they can check against the actual symbol number, without having pay (space and time) a conversion.  See https://lists.gnu.org/r/bug-bison/2020-01/msg00001.html, and https://lists.gnu.org/archive/html/bug-bison/2020-03/msg00015.html.

- it helps us clearly separate the internal symbol numbers from the external token numbers, whose difference is sometimes blurred in the code when values coincide (e.g. `yychar = yytoken = YYEOF`).

- it allows us to get rid of ugly macros with inconsistent names such as `YYUNDEFTOK` and `YYTERROR`, and to group related definitions together.

- similarly it provides a clean access to the `$accept` symbol (which proves convenient in a current experimentation of mine with several `%start` symbols).

I would also like to move the lone `#define`s for `YYEOF` and `YYEMPTY` into `yytokentype`, so that we can use strong typing for both `yytoken` and `yychar`.  And get rid of more macros.
