### PR TITLE
yypstate_clear (ATTENTION push parser users)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -42,6 +42,22 @@ GNU Bison NEWS
     filename_type       -> api.filename.type
     package             -> api.package
 
+*** Push parser state
+
+** Backward incompatible changes
+
+*** Push parsers no longer clear their state when parsing is finished
+
+  Previously push-parsers cleared their state when parsing was finished (on
+  success and on failure).  This made it impossible to check if there were
+  parse errors, since `yynerrs` was also reset.  This can be especially
+  troublesome when used in autocompletion, since a parser with error
+  recovery would suggest (irrelevant) expected tokens even if there were
+  failure.
+
+  Now the parser state can be examined when parsing is finished.  The parser
+  state is reset when starting a new parse.
+
 ** Bug fixes
 
 *** Include the generated header (yacc.c)

--- a/TODO
+++ b/TODO
@@ -37,8 +37,6 @@ Unless we play it dumb (little structure).
 examples about conflicts in the reports.
 
 ** Bistromathic
-- Hitting tab on a line with a syntax error is ugly
-
 - How about not evaluating incomplete lines when the text is not finished
   (as shells do).
 

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -176,48 +176,47 @@ YYLTYPE yylloc]b4_yyloc_default[;]])[
 int yynerrs;]])])
 
 
-# b4_declare_parser_state_variables
-# ---------------------------------
+# b4_declare_parser_state_variables([INIT])
+# -----------------------------------------
 # Declare all the variables that are needed to maintain the parser state
 # between calls to yypush_parse.
+# If INIT is non-null, initialize these variables.
 m4_define([b4_declare_parser_state_variables],
 [b4_pure_if([[
     /* Number of syntax errors so far.  */
-    int yynerrs;
+    int yynerrs]m4_ifval([$1], [ = 0])[;
 ]])[
-    yy_state_fast_t yystate;
+    yy_state_fast_t yystate]m4_ifval([$1], [ = 0])[;
     /* Number of tokens to shift before error messages enabled.  */
-    int yyerrstatus;
+    int yyerrstatus]m4_ifval([$1], [ = 0])[;
 
-    /* The stacks and their tools:
-       'yyss': related to states.
-       'yyvs': related to semantic values.]b4_locations_if([[
-       'yyls': related to locations.]])[
-
-       Refer to the stacks through separate pointers, to allow yyoverflow
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
 
     /* Their size.  */
-    YYPTRDIFF_T yystacksize;
+    YYPTRDIFF_T yystacksize]m4_ifval([$1], [ = YYINITDEPTH])[;
 
-    /* The state stack.  */
+    /* The state stack: array, bottom, top.  */
     yy_state_t yyssa[YYINITDEPTH];
-    yy_state_t *yyss;
-    yy_state_t *yyssp;
+    yy_state_t *yyss]m4_ifval([$1], [ = yyssa])[;
+    yy_state_t *yyssp]m4_ifval([$1], [ = yyss])[;
 
-    /* The semantic value stack.  */
+    /* The semantic value stack: array, bottom, top.  */
     YYSTYPE yyvsa[YYINITDEPTH];
-    YYSTYPE *yyvs;
-    YYSTYPE *yyvsp;]b4_locations_if([[
+    YYSTYPE *yyvs]m4_ifval([$1], [ = yyvsa])[;
+    YYSTYPE *yyvsp]m4_ifval([$1], [ = yyvs])[;]b4_locations_if([[
 
-    /* The location stack.  */
+    /* The location stack: array, bottom, top.  */
     YYLTYPE yylsa[YYINITDEPTH];
-    YYLTYPE *yyls;
-    YYLTYPE *yylsp;]])[]b4_lac_if([[
+    YYLTYPE *yyls]m4_ifval([$1], [ = yylsa])[;
+    YYLTYPE *yylsp]m4_ifval([$1], [ = yyls])[;]])[]b4_lac_if([[
 
     yy_state_t yyesa@{]b4_percent_define_get([[parse.lac.es-capacity-initial]])[@};
-    yy_state_t *yyes;
-    YYPTRDIFF_T yyes_capacity;]])])
+    yy_state_t *yyes]m4_ifval([$1], [ = yyesa])[;
+    YYPTRDIFF_T yyes_capacity][]m4_ifval([$1],
+            [m4_do([ = b4_percent_define_get([[parse.lac.es-capacity-initial]]) < YYMAXDEPTH],
+                   [ ? b4_percent_define_get([[parse.lac.es-capacity-initial]])],
+                   [ : YYMAXDEPTH])])[;]])])
 
 
 # b4_initialize_parser_state_variables
@@ -1542,7 +1541,7 @@ yyparse (]m4_ifset([b4_parse_param], [b4_formals(b4_parse_param)], [void])[)]])[
   YYSTYPE yypushed_val = yylval;]b4_locations_if([[
   YYLTYPE yypushed_loc = yylloc;]])
 ])],
-  [b4_declare_parser_state_variables
+  [b4_declare_parser_state_variables([init])
 ])b4_lac_if([[
   /* Whether LAC context is established.  A Boolean.  */
   int yy_lac_established = 0;]])[
@@ -1569,14 +1568,13 @@ yyparse (]m4_ifset([b4_parse_param], [b4_formals(b4_parse_param)], [void])[)]])[
 
   /* The number of symbols on the RHS of the reduced rule.
      Keep to zero when no symbol should be popped.  */
-  int yylen = 0;
-]b4_push_if([[
+  int yylen = 0;]b4_push_if([[
+
   if (!yyps->yynew)
     {
       yyn = yypact[yystate];
       goto yyread_pushed_token;
-    }]], [
-b4_initialize_parser_state_variables])[
+    }]])[
 
   YYDPRINTF ((stderr, "Starting parse\n"));
 

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -219,26 +219,6 @@ m4_define([b4_declare_parser_state_variables],
                    [ : YYMAXDEPTH])])[;]])])
 
 
-# b4_initialize_parser_state_variables
-# ------------------------------------
-# Initialize these variables.
-m4_define([b4_initialize_parser_state_variables],
-[[  yynerrs = 0;
-  yystate = 0;
-  yyerrstatus = 0;
-
-  yystacksize = YYINITDEPTH;
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;]b4_locations_if([[
-  yylsp = yyls = yylsa;]])[]b4_lac_if([[
-
-  yyes = yyesa;
-  yyes_capacity = ]b4_percent_define_get([[parse.lac.es-capacity-initial]])[;
-  if (YYMAXDEPTH < yyes_capacity)
-    yyes_capacity = YYMAXDEPTH;]])[
-]])
-
-
 m4_define([b4_macro_define],
 [[#]define $1 $2])
 
@@ -1479,7 +1459,19 @@ yypull_parse (yypstate *yyps]b4_user_formals[)
 static void
 yypstate_clear (yypstate *yyps)
 {
-]b4_initialize_parser_state_variables[
+  yynerrs = 0;
+  yystate = 0;
+  yyerrstatus = 0;
+
+  yystacksize = YYINITDEPTH;
+  yyssp = yyss = yyssa;
+  yyvsp = yyvs = yyvsa;]b4_locations_if([[
+  yylsp = yyls = yylsa;]])[]b4_lac_if([[
+
+  yyes = yyesa;
+  yyes_capacity = ]b4_percent_define_get([[parse.lac.es-capacity-initial]])[;
+  if (YYMAXDEPTH < yyes_capacity)
+    yyes_capacity = YYMAXDEPTH;]])[
   /* Initialize the state stack, in case yypcontext_expected_tokens is
      called before the first call to yyparse. */
   *yyssp = 0;

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -1444,36 +1444,33 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
 int
 yyparse (]m4_ifset([b4_parse_param], [b4_formals(b4_parse_param)], [void])[)
 {
-  return yypull_parse (YY_NULLPTR]b4_user_args[);
+  yypstate *yyps = yypstate_new ();
+  if (!yyps)
+    {]b4_pure_if([b4_locations_if([[
+      static YYLTYPE yyloc_default][]b4_yyloc_default[;
+      YYLTYPE yylloc = yyloc_default;]])[
+      yyerror (]b4_yyerror_args[YY_("memory exhausted"));]], [[
+      if (!yypstate_allocated)
+        yyerror (]b4_yyerror_args[YY_("memory exhausted"));]])[
+      return 2;
+    }
+  int yystatus = yypull_parse (yyps]b4_user_args[);
+  yypstate_delete (yyps);
+  return yystatus;
 }
 
 int
 yypull_parse (yypstate *yyps]b4_user_formals[)
-{]b4_pure_if([b4_locations_if([[
+{
+  YY_ASSERT (yyps);]b4_pure_if([b4_locations_if([[
   static YYLTYPE yyloc_default][]b4_yyloc_default[;
   YYLTYPE yylloc = yyloc_default;]])])[
-  yypstate *yyps_local;
-  if (yyps)
-    yyps_local = yyps;
-  else
-    {
-      yyps_local = yypstate_new ();
-      if (!yyps_local)
-        {]b4_pure_if([[
-          yyerror (]b4_yyerror_args[YY_("memory exhausted"));]], [[
-          if (!yypstate_allocated)
-            yyerror (]b4_yyerror_args[YY_("memory exhausted"));]])[
-          return 2;
-        }
-    }
   int yystatus;
   do {
 ]b4_pure_if([[    YYSTYPE yylval;
     int ]])[yychar = ]b4_lex[;
-    yystatus = yypush_parse (yyps_local]b4_pure_if([[, yychar, &yylval]b4_locations_if([[, &yylloc]])])m4_ifset([b4_parse_param], [, b4_args(b4_parse_param)])[);
+    yystatus = yypush_parse (yyps]b4_pure_if([[, yychar, &yylval]b4_locations_if([[, &yylloc]])])m4_ifset([b4_parse_param], [, b4_args(b4_parse_param)])[);
   } while (yystatus == YYPUSH_MORE);
-  if (!yyps)
-    yypstate_delete (yyps_local);
   return yystatus;
 }]])[
 

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -2045,13 +2045,13 @@ yyabortlab:
 yyexhaustedlab:
   yyerror (]b4_yyerror_args[YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
+  goto yyreturn;
 #endif
 
 
-/*-----------------------------------------------------.
-| yyreturn -- parsing is finished, return the result.  |
-`-----------------------------------------------------*/
+/*-------------------------------------------------------.
+| yyreturn -- parsing is finished, clean up and return.  |
+`-------------------------------------------------------*/
 yyreturn:
   if (yychar != ]b4_symbol(-2, id)[)
     {
@@ -2079,11 +2079,12 @@ yyreturn:
     YYSTACK_FREE (yyes);]])b4_push_if([[
   yypstate_clear (yyps);
   yyps->yynew = 1;
+  goto yypushreturn;
 
 
-/*-----------------------------------------.
-| yypushreturn -- ask for the next token.  |
-`-----------------------------------------*/
+/*-------------------------.
+| yypushreturn -- return.  |
+`-------------------------*/
 yypushreturn:]])[
 ]b4_parse_error_bmatch([detailed\|verbose],
 [[  if (yymsg != yymsgbuf)

--- a/data/skeletons/yacc.c
+++ b/data/skeletons/yacc.c
@@ -808,7 +808,8 @@ int yydebug;
 /* Parser data structure.  */
 struct yypstate
   {]b4_declare_parser_state_variables[
-    /* Whether this instance has not started parsing yet.  */
+    /* Whether this instance has not started parsing yet.
+     * If 2, it corresponds to a finished parsing.  */
     int yynew;
   };]b4_pure_if([], [[
 
@@ -1463,18 +1464,14 @@ yypstate_clear (yypstate *yyps)
   yystate = 0;
   yyerrstatus = 0;
 
-  yystacksize = YYINITDEPTH;
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;]b4_locations_if([[
-  yylsp = yyls = yylsa;]])[]b4_lac_if([[
+  yyssp = yyss;
+  yyvsp = yyvs;]b4_locations_if([[
+  yylsp = yyls;]])[
 
-  yyes = yyesa;
-  yyes_capacity = ]b4_percent_define_get([[parse.lac.es-capacity-initial]])[;
-  if (YYMAXDEPTH < yyes_capacity)
-    yyes_capacity = YYMAXDEPTH;]])[
   /* Initialize the state stack, in case yypcontext_expected_tokens is
      called before the first call to yyparse. */
   *yyssp = 0;
+  yyps->yynew = 1;
 }
 
 /* Initialize the parser data structure.  */
@@ -1486,9 +1483,16 @@ yypstate_new (void)
     return YY_NULLPTR;]])[
   yyps = YY_CAST (yypstate *, malloc (sizeof *yyps));
   if (!yyps)
-    return YY_NULLPTR;
-  yyps->yynew = 1;]b4_pure_if([], [[
+    return YY_NULLPTR;]b4_pure_if([], [[
   yypstate_allocated = 1;]])[
+  yystacksize = YYINITDEPTH;
+  yyss = yyssa;
+  yyvs = yyvsa;]b4_locations_if([[
+  yyls = yylsa;]])[]b4_lac_if([[
+  yyes = yyesa;
+  yyes_capacity = ]b4_percent_define_get([[parse.lac.es-capacity-initial]])[;
+  if (YYMAXDEPTH < yyes_capacity)
+    yyes_capacity = YYMAXDEPTH;]])[
   yypstate_clear (yyps);
   return yyps;
 }
@@ -1501,10 +1505,10 @@ yypstate_delete (yypstate *yyps)
 #ifndef yyoverflow
       /* If the stack was reallocated but the parse did not complete, then the
          stack still needs to be freed.  */
-      if (!yyps->yynew && yyss != yyssa)
+      if (yyss != yyssa)
         YYSTACK_FREE (yyss);
 #endif]b4_lac_if([[
-      if (!yyps->yynew && yyes != yyesa)
+      if (yyes != yyesa)
         YYSTACK_FREE (yyes);]])[
       free (yyps);]b4_pure_if([], [[
       yypstate_allocated = 0;]])[
@@ -1562,8 +1566,14 @@ yyparse (]m4_ifset([b4_parse_param], [b4_formals(b4_parse_param)], [void])[)]])[
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;]b4_push_if([[
 
-  if (!yyps->yynew)
+  switch (yyps->yynew)
     {
+    case 2:
+      yypstate_clear (yyps);
+      goto case_0;
+
+    case_0:
+    case 0:
       yyn = yypact[yystate];
       goto yyread_pushed_token;
     }]])[
@@ -2060,22 +2070,21 @@ yyreturn:
       yydestruct ("Cleanup: popping",
                   YY_ACCESSING_SYMBOL (+*yyssp), yyvsp]b4_locations_if([, yylsp])[]b4_user_args[);
       YYPOPSTACK (1);
-    }
-#ifndef yyoverflow
-  if (yyss != yyssa)
-    YYSTACK_FREE (yyss);
-#endif]b4_lac_if([[
-  if (yyes != yyesa)
-    YYSTACK_FREE (yyes);]])b4_push_if([[
-  yypstate_clear (yyps);
-  yyps->yynew = 1;
+    }]b4_push_if([[
+  yyps->yynew = 2;
   goto yypushreturn;
 
 
 /*-------------------------.
 | yypushreturn -- return.  |
 `-------------------------*/
-yypushreturn:]])[
+yypushreturn:]], [[
+#ifndef yyoverflow
+  if (yyss != yyssa)
+    YYSTACK_FREE (yyss);
+#endif]b4_lac_if([[
+  if (yyes != yyesa)
+    YYSTACK_FREE (yyes);]])])[
 ]b4_parse_error_bmatch([detailed\|verbose],
 [[  if (yymsg != yymsgbuf)
     YYSTACK_FREE (yymsg);]])[

--- a/doc/bison.texi
+++ b/doc/bison.texi
@@ -7146,6 +7146,10 @@ The value returned by @code{yypush_parse} is the same as for @code{yyparse}
 with the following exception: it returns @code{YYPUSH_MORE} if more input is
 required to finish parsing the grammar.
 
+After @code{yypush_parse} returned, the instance may be consulted.  For
+instance check @code{yynerrs} to see whether there were (possibly recovered)
+syntax errors.
+
 After @code{yypush_parse} returns a status other than @code{YYPUSH_MORE},
 the parser instance @code{yyps} may be reused for a new parse.
 @end deftypefun

--- a/examples/c/bistromathic/bistromathic.test
+++ b/examples/c/bistromathic/bistromathic.test
@@ -307,16 +307,24 @@ end of file  exit         exp          ''
 > ''
 err: '
 
-# Check that completion when there is an error prints valid locations.
+# Check that completion prints valid locations even when there is an error.
+sed -e 's/\\t/	/g' >input <<EOF
+1++\t
+EOF
+run -n 0 '> 1++ ''
+> ''
+err: 1.1: syntax error: expected - or ( or number or function or variable before +
+err: 1.3: syntax error: expected - or ( or number or function or variable before +
+'
+
+# And even when the error was recovered from.
 sed -e 's/\\t/	/g' >input <<EOF
 (1++2) + 3 +\t\t
 EOF
-run -n 0 '> (1++2) + 3 +
-(       -       atan    cos     exp     ln      number  sin     sqrt
-> (1++2) + 3 +
+run -n 0 '> (1++2) + 3 +  ''
 > 
 err: 1.1: syntax error: expected - or ( or number or function or variable before +
-err: 1.1: syntax error: expected - or ( or number or function or variable before +
+err: 1.1: syntax error: expected - or ( or number or function or variable before +
 err: 1.4: syntax error: expected - or ( or number or function or variable before +
-err: 1.13: syntax error: expected - or ( or number or function or variable before end of file
+err: 1.15: syntax error: expected - or ( or number or function or variable before end of file
 '

--- a/examples/c/bistromathic/bistromathic.test
+++ b/examples/c/bistromathic/bistromathic.test
@@ -306,3 +306,17 @@ end of file  exit         exp          ''
 0
 > ''
 err: '
+
+# Check that completion when there is an error prints valid locations.
+sed -e 's/\\t/	/g' >input <<EOF
+(1++2) + 3 +\t\t
+EOF
+run -n 0 '> (1++2) + 3 +
+(       -       atan    cos     exp     ln      number  sin     sqrt
+> (1++2) + 3 +
+> 
+err: 1.1: syntax error: expected - or ( or number or function or variable before +
+err: 1.1: syntax error: expected - or ( or number or function or variable before +
+err: 1.4: syntax error: expected - or ( or number or function or variable before +
+err: 1.13: syntax error: expected - or ( or number or function or variable before end of file
+'

--- a/examples/c/bistromathic/parse.y
+++ b/examples/c/bistromathic/parse.y
@@ -447,7 +447,7 @@ expected_tokens (const char *input,
   yypstate *ps = yypstate_new ();
   int status = 0;
   do {
-    YYLTYPE lloc;
+    YYLTYPE lloc = { 1, 1, 1, 1 };
     YYSTYPE lval;
     int token = yylex (&input, &lval, &lloc);
     // Don't let the parse know when we reach the end of input.

--- a/examples/c/bistromathic/parse.y
+++ b/examples/c/bistromathic/parse.y
@@ -456,10 +456,15 @@ expected_tokens (const char *input,
     status = yypush_parse (ps, token, &lval, &lloc);
   } while (status == YYPUSH_MORE);
 
-  // Then query for the accepted tokens at this point.
-  int res = yypstate_expected_tokens (ps, tokens, ntokens);
-  if (res < 0)
-    abort ();
+  int res = 0;
+  // If there were parse errors, don't propose completions.
+  if (!ps->yynerrs)
+    {
+      // Then query for the accepted tokens at this point.
+      res = yypstate_expected_tokens (ps, tokens, ntokens);
+      if (res < 0)
+        abort ();
+    }
   yypstate_delete (ps);
   return res;
 }

--- a/src/parse-gram.c
+++ b/src/parse-gram.c
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.6.3.87-3efc5-dirty.  */
+/* A Bison parser, made by GNU Bison 3.6.4.130-76c4d.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
@@ -49,7 +49,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.6.3.87-3efc5-dirty"
+#define YYBISON_VERSION "3.6.4.130-76c4d"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -1767,41 +1767,36 @@ static YYLTYPE yyloc_default
 YYLTYPE yylloc = yyloc_default;
 
     /* Number of syntax errors so far.  */
-    int yynerrs;
+    int yynerrs = 0;
 
-    yy_state_fast_t yystate;
+    yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */
-    int yyerrstatus;
+    int yyerrstatus = 0;
 
-    /* The stacks and their tools:
-       'yyss': related to states.
-       'yyvs': related to semantic values.
-       'yyls': related to locations.
-
-       Refer to the stacks through separate pointers, to allow yyoverflow
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
 
     /* Their size.  */
-    YYPTRDIFF_T yystacksize;
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
 
-    /* The state stack.  */
+    /* The state stack: array, bottom, top.  */
     yy_state_t yyssa[YYINITDEPTH];
-    yy_state_t *yyss;
-    yy_state_t *yyssp;
+    yy_state_t *yyss = yyssa;
+    yy_state_t *yyssp = yyss;
 
-    /* The semantic value stack.  */
+    /* The semantic value stack: array, bottom, top.  */
     YYSTYPE yyvsa[YYINITDEPTH];
-    YYSTYPE *yyvs;
-    YYSTYPE *yyvsp;
+    YYSTYPE *yyvs = yyvsa;
+    YYSTYPE *yyvsp = yyvs;
 
-    /* The location stack.  */
+    /* The location stack: array, bottom, top.  */
     YYLTYPE yylsa[YYINITDEPTH];
-    YYLTYPE *yyls;
-    YYLTYPE *yylsp;
+    YYLTYPE *yyls = yylsa;
+    YYLTYPE *yylsp = yyls;
 
     yy_state_t yyesa[20];
-    yy_state_t *yyes;
-    YYPTRDIFF_T yyes_capacity;
+    yy_state_t *yyes = yyesa;
+    YYPTRDIFF_T yyes_capacity = 20 < YYMAXDEPTH ? 20 : YYMAXDEPTH;
 
   /* Whether LAC context is established.  A Boolean.  */
   int yy_lac_established = 0;
@@ -1825,21 +1820,6 @@ YYLTYPE yylloc = yyloc_default;
   /* The number of symbols on the RHS of the reduced rule.
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
-
-  yynerrs = 0;
-  yystate = 0;
-  yyerrstatus = 0;
-
-  yystacksize = YYINITDEPTH;
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;
-  yylsp = yyls = yylsa;
-
-  yyes = yyesa;
-  yyes_capacity = 20;
-  if (YYMAXDEPTH < yyes_capacity)
-    yyes_capacity = YYMAXDEPTH;
-
 
   YYDPRINTF ((stderr, "Starting parse\n"));
 
@@ -2784,13 +2764,13 @@ yyabortlab:
 yyexhaustedlab:
   yyerror (&yylloc, YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
+  goto yyreturn;
 #endif
 
 
-/*-----------------------------------------------------.
-| yyreturn -- parsing is finished, return the result.  |
-`-----------------------------------------------------*/
+/*-------------------------------------------------------.
+| yyreturn -- parsing is finished, clean up and return.  |
+`-------------------------------------------------------*/
 yyreturn:
   if (yychar != GRAM_EMPTY)
     {

--- a/src/parse-gram.h
+++ b/src/parse-gram.h
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.6.3.87-3efc5-dirty.  */
+/* A Bison parser, made by GNU Bison 3.6.4.130-76c4d.  */
 
 /* Bison interface for Yacc-like parsers in C
 


### PR DESCRIPTION
Push parser users should pay special attention to these changes, and provide feedback.

If you are used to code such as

```
yypstate *ps = yypstate_new ();
for (int i = 1; i < argc; ++i)
  yypull_parse (ps);
yypstate_delete (ps);
```

you will have to make it

```
yypstate *ps = yypstate_new ();
for (int i = 1; i < argc; ++i)
  {
    yypstate_clear (ps);
    yypull_parse (ps);
  }
yypstate_delete (ps);
```

IMHO, the previous design was flawed, as it prevented introspecting the parser state to see what happened.  Besides, if the initial stacks were too smalls, and had been enlarged, in the later runs we are back to using the "small" stacks.

These changes allowed to fix undesirable behaviors in autocompletion. But I also expect we will want more means to study the state stack in the future, so we should really preserve our parser state.

In the future, we could also not clear the stack at the end of parsing, but in yypstate_clear and yypstate_delete.  This could have some impact on when users expect the destructors are called, so that's a whole new chapter.
