### PR TITLE
glr2.cc: avoid warnings about printf and shadowing

### DIFF
--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -1,3 +1,4 @@
+/inttypes-pri.m4
 /*~
 /00gnulib.m4
 /__inline.m4
@@ -67,7 +68,6 @@
 /intlmacosx.m4
 /intmax.m4
 /intmax_t.m4
-/inttypes-pri.m4
 /inttypes.m4
 /inttypes_h.m4
 /isnan.m4


### PR DESCRIPTION
Migrate from using printf to std::cerr & co.
Since the yyGLRStack has the user params, no need to pass them around.