### PR TITLE
d: change the name of the custom error message function to reportSynt…

### DIFF
--- a/data/skeletons/lalr1.d
+++ b/data/skeletons/lalr1.d
@@ -84,7 +84,7 @@ public interface Lexer
    *
    * @@param ctx  The context of the error.
    */
-  void syntax_error(]b4_parser_class[.Context ctx);
+  void reportSyntaxError(]b4_parser_class[.Context ctx);
 ]])[
 }
 
@@ -675,7 +675,7 @@ m4_popdef([b4_at_dollar])])dnl
   private final void yyreportSyntaxError(Context yyctx)
   {]b4_parse_error_bmatch(
 [custom], [[
-    yylexer.syntax_error(yyctx);]],
+    yylexer.reportSyntaxError(yyctx);]],
 [detailed\|verbose], [[
     if (yyctx.getToken() != ]b4_symbol(empty, kind)[)
     {

--- a/doc/bison.texi
+++ b/doc/bison.texi
@@ -14026,7 +14026,7 @@ They should return new objects for each call, to avoid that all the symbol
 share the same Position boundaries.
 @end deftypemethod
 
-@deftypemethod {Lexer} {void} syntax_error(@code{YYParser.Context} @var{ctx})
+@deftypemethod {Lexer} {void} reportSyntaxError(@code{YYParser.Context} @var{ctx})
 If you invoke @samp{%define parse.error custom} (@pxref{Bison
 Declarations}), then the parser no longer passes syntax error messages to
 @code{yyerror}, rather it delegates that task to the user by calling the
@@ -14038,7 +14038,7 @@ Here is an example of a reporting function (@pxref{D Parser Context
 Interface}).
 
 @example
-public void syntax_error(YYParser.Context ctx)
+public void reportSyntaxError(YYParser.Context ctx)
 @{
   stderr.write(ctx.getLocation(), ": syntax error");
   // Report the expected tokens.

--- a/tests/local.at
+++ b/tests/local.at
@@ -891,7 +891,7 @@ public string transformToken(]AT_API_PREFIX[Parser.SymbolKind token)
     return res;
 }
 
-public void syntax_error(]AT_API_PREFIX[Parser.Context ctx)
+public void reportSyntaxError(]AT_API_PREFIX[Parser.Context ctx)
 {
   stderr.write(]AT_LOCATION_IF([[ctx.getLocation(), ": ",]])["syntax error");
   {


### PR DESCRIPTION
…axError

Changed from syntax_error to reportSyntaxError to be similar to the Java parser.

* data/skeletons/lalr1.d: Change the function name.
* doc/bison.texi: Document it.
* tests/local.at: Adjust.