### PR TITLE
d: add support for lookahead correction

### DIFF
--- a/doc/bison.texi
+++ b/doc/bison.texi
@@ -6885,7 +6885,7 @@ introduced in 3.0 with support for @code{simple} and @code{verbose}.  Values
 @deffn Directive {%define parse.lac} @var{when}
 
 @itemize
-@item Languages(s): C/C++ (deterministic parsers only), and Java.
+@item Languages(s): C/C++ (deterministic parsers only), D and Java.
 
 @item Purpose: Enable LAC (lookahead correction) to improve
 syntax error handling.  @xref{LAC}.

--- a/tests/calc.at
+++ b/tests/calc.at
@@ -1461,6 +1461,10 @@ AT_CHECK_CALC_LALR1_D([%define parse.error verbose %debug %define api.token.pref
 AT_CHECK_CALC_LALR1_D([%define parse.error verbose %debug %define api.symbol.prefix {SYMB_} %verbose])
 AT_CHECK_CALC_LALR1_D([%define parse.error verbose %debug %define api.symbol.prefix {SYMB_} %define api.token.prefix {TOK_} %verbose])
 
+AT_CHECK_CALC_LALR1_D([%locations %define parse.lac full %define parse.error verbose])
+AT_CHECK_CALC_LALR1_D([%locations %define parse.lac full %define parse.error custom])
+AT_CHECK_CALC_LALR1_D([%locations %define parse.lac full %define parse.error detailed %define parse.trace])
+
 #AT_CHECK_CALC_LALR1_D([%locations %define parse.error verbose %debug %verbose %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 #AT_CHECK_CALC_LALR1_D([%locations %define parse.error verbose %debug %define api.prefix {calc} %verbose %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 


### PR DESCRIPTION
When using lookahead correction, the method YYParser.Context.getExpectedTokens
is not annotated with const, because the method calls yylacCheck, which is not
const. Also, because of yylacStack and yylacEstablished, yylacCheck needs to
be called from the context of the parser class, which is sent as parameter to
the Context's constructor.

* data/skeletons/lalr1.d (yylacCheck, yylacEstablish, yylacDiscard,
yylacStack, yylacEstablished): New.
(Context): Use it.
* doc/bison.texi: Document it.
* tests/calc.at: Check it.