### PR TITLE
d: remove support for parse.error verbose

### DIFF
--- a/data/skeletons/lalr1.d
+++ b/data/skeletons/lalr1.d
@@ -693,7 +693,7 @@ m4_popdef([b4_at_dollar])])dnl
   {]b4_parse_error_bmatch(
 [custom], [[
     yylexer.reportSyntaxError(yyctx);]],
-[detailed\|verbose], [[
+[detailed], [[
     if (yyctx.getToken() != ]b4_symbol(empty, kind)[)
     {
       // FIXME: This method of building the message is not compatible
@@ -735,7 +735,7 @@ m4_popdef([b4_at_dollar])])dnl
   }
 
 ]b4_parse_error_bmatch(
-[detailed\|verbose], [[
+[detailed], [[
   private int yysyntaxErrorArguments(Context yyctx, SymbolKind[] yyarg, int yyargn) {
     /* There are many possibilities here to consider:
        - If this state is a consistent state with a default action,

--- a/doc/bison.texi
+++ b/doc/bison.texi
@@ -13919,7 +13919,7 @@ Run the syntactic analysis, and return @code{true} on success,
 @deftypemethod {YYParser} {boolean} getErrorVerbose()
 @deftypemethodx {YYParser} {void} setErrorVerbose(boolean @var{verbose})
 Get or set the option to produce verbose error messages.  These are only
-available with @samp{%define parse.error detailed} (or @samp{verbose}),
+available with @samp{%define parse.error detailed},
 which also turns on verbose error messages.
 @end deftypemethod
 

--- a/tests/calc.at
+++ b/tests/calc.at
@@ -1453,7 +1453,7 @@ m4_define([AT_CHECK_CALC_LALR1_D],
 AT_CHECK_CALC_LALR1_D([])
 AT_CHECK_CALC_LALR1_D([%locations])
 #AT_CHECK_CALC_LALR1_D([%locations %define api.location.type {Span}])
-AT_CHECK_CALC_LALR1_D([%define parse.error verbose %define api.prefix {calc} %verbose])
+AT_CHECK_CALC_LALR1_D([%define parse.error detailed %define api.prefix {calc} %verbose])
 
 AT_CHECK_CALC_LALR1_D([%debug])
 
@@ -1461,18 +1461,17 @@ AT_CHECK_CALC_LALR1_D([%define parse.error custom])
 AT_CHECK_CALC_LALR1_D([%locations %define parse.error custom])
 AT_CHECK_CALC_LALR1_D([%locations %define parse.error detailed])
 AT_CHECK_CALC_LALR1_D([%locations %define parse.error simple])
-AT_CHECK_CALC_LALR1_D([%locations %define parse.error verbose])
-AT_CHECK_CALC_LALR1_D([%define parse.error verbose %debug %verbose])
-AT_CHECK_CALC_LALR1_D([%define parse.error verbose %debug %define api.token.prefix {TOK_} %verbose])
-AT_CHECK_CALC_LALR1_D([%define parse.error verbose %debug %define api.symbol.prefix {SYMB_} %verbose])
-AT_CHECK_CALC_LALR1_D([%define parse.error verbose %debug %define api.symbol.prefix {SYMB_} %define api.token.prefix {TOK_} %verbose])
+AT_CHECK_CALC_LALR1_D([%define parse.error detailed %debug %verbose])
+AT_CHECK_CALC_LALR1_D([%define parse.error detailed %debug %define api.token.prefix {TOK_} %verbose])
+AT_CHECK_CALC_LALR1_D([%define parse.error detailed %debug %define api.symbol.prefix {SYMB_} %verbose])
+AT_CHECK_CALC_LALR1_D([%define parse.error detailed %debug %define api.symbol.prefix {SYMB_} %define api.token.prefix {TOK_} %verbose])
 
-AT_CHECK_CALC_LALR1_D([%locations %define parse.lac full %define parse.error verbose])
+AT_CHECK_CALC_LALR1_D([%locations %define parse.lac full %define parse.error detailed])
 AT_CHECK_CALC_LALR1_D([%locations %define parse.lac full %define parse.error custom])
 AT_CHECK_CALC_LALR1_D([%locations %define parse.lac full %define parse.error detailed %define parse.trace])
 
-#AT_CHECK_CALC_LALR1_D([%locations %define parse.error verbose %debug %verbose %parse-param {semantic_value *result}{int *count}{int *nerrs}])
-#AT_CHECK_CALC_LALR1_D([%locations %define parse.error verbose %debug %define api.prefix {calc} %verbose %parse-param {semantic_value *result}{int *count}{int *nerrs}])
+#AT_CHECK_CALC_LALR1_D([%locations %define parse.error detailed %debug %verbose %parse-param {semantic_value *result}{int *count}{int *nerrs}])
+#AT_CHECK_CALC_LALR1_D([%locations %define parse.error detailed %debug %define api.prefix {calc} %verbose %parse-param {semantic_value *result}{int *count}{int *nerrs}])
 
 
 # ----------------------- #


### PR DESCRIPTION
Without the history, D should not support this option. Before the
removal, 'detailed' and 'verbose' options generated the same code.

* data/skeletons/lalr1.d: Here.
* doc/bison.texi: Adapt tests to use 'detailed' instead of 'verbose'.
* tests/calc.at: Document it.