### PR TITLE
Add two new options to output the naked grammar and an EBNF

### DIFF
--- a/src/getargs.c
+++ b/src/getargs.c
@@ -38,6 +38,8 @@
 #include "output.h"
 #include "uniqstr.h"
 
+bool rrebnf_flag = false;
+bool naked_flag = false;
 bool header_flag = false;
 bool graph_flag = false;
 bool html_flag = false;
@@ -425,6 +427,8 @@ Tuning the Parser:\n\
 
       fputs (_("\
 Output Files:\n\
+  -e                            generate RREBNF\n\
+  -n                            generate naked grammar\n\
   -H, --header=[FILE]           also produce a header file\n\
   -d                            likewise but cannot specify FILE (for POSIX Yacc)\n\
   -r, --report=THINGS           also produce details on the automaton\n\
@@ -552,6 +556,8 @@ static char const short_options[] =
   "W::"
   "b:"
   "d"
+  "e"
+  "n"
   "f::"
   "g::"
   "h"
@@ -610,6 +616,8 @@ static struct option const long_options[] =
   { "yacc",           no_argument,         0, 'y' },
 
   /* Output Files. */
+  { "rrebnf",          optional_argument,   0,   'e' },
+  { "naked",           optional_argument,   0,   'n' },
   { "header",          optional_argument,   0,   'H' },
   { "defines",         optional_argument,   0,   'd' },
   { "report",          required_argument,   0,   'r' },
@@ -774,6 +782,14 @@ getargs (int argc, char *argv[])
 
       case 'b':
         spec_file_prefix = optarg;
+        break;
+
+      case 'e':
+        rrebnf_flag = true;
+        break;
+
+      case 'n':
+        naked_flag = true;
         break;
 
       case 'g':

--- a/src/getargs.h
+++ b/src/getargs.h
@@ -34,6 +34,8 @@ extern int skeleton_prio;
 /* for -I */
 extern char const *include;
 
+extern bool rrebnf_flag;                /* for -e */
+extern bool naked_flag;                 /* for -n */
 extern bool header_flag;                /* for -d/-H */
 extern bool graph_flag;                 /* for -g */
 extern bool html_flag;                  /* for --html */

--- a/src/reader.c
+++ b/src/reader.c
@@ -816,6 +816,63 @@ find_start_symbol (void)
   return res->content.sym;
 }
 
+static void
+print_naked_rules(void)
+{
+  int starting_new_rule = 1, rhs_count = 1;
+  uniqstr prev_rule = NULL;
+  for (symbol_list *sym = grammar; sym; sym = sym->next) {
+      if(sym->content_type == SYMLIST_SYMBOL) {
+          if(!sym->content.sym) {
+              starting_new_rule = 1;
+              continue;
+          }
+          if(starting_new_rule) {
+            if(rhs_count == 0) printf("/* empty */");
+            if(prev_rule && prev_rule != sym->content.sym->tag)
+                printf("\n\t;");
+            if(prev_rule == sym->content.sym->tag) printf("\n\t| ");
+            else printf("\n\n%s :\n\t", sym->content.sym->tag);
+            starting_new_rule = rhs_count = 0;
+            prev_rule = sym->content.sym->tag;
+          }
+          else {
+            printf("%s ", sym->content.sym->tag);
+            ++rhs_count;
+          }
+      }
+  }
+  printf("\n\t;\n");
+  fflush(stdout);
+}
+
+static void
+print_rrebnf(void)
+{
+  int starting_new_rule = 1, rhs_count = 1;
+  uniqstr prev_rule = NULL;
+  for (symbol_list *sym = grammar; sym; sym = sym->next) {
+      if(sym->content_type == SYMLIST_SYMBOL) {
+          if(!sym->content.sym) {
+              starting_new_rule = 1;
+              continue;
+          }
+          if(starting_new_rule) {
+            if(rhs_count == 0) printf("/* empty */");
+            if(prev_rule == sym->content.sym->tag) printf("\n\t| ");
+            else printf("\n\n%s ::=\n\t", sym->content.sym->tag);
+            starting_new_rule = rhs_count = 0;
+            prev_rule = sym->content.sym->tag;
+          }
+          else {
+            printf("%s ", sym->content.sym->tag);
+            ++rhs_count;
+          }
+      }
+  }
+  printf("\n\n");
+  fflush(stdout);
+}
 
 /* Insert an initial rule, whose location is that of the first rule
    (not that of the start symbol):
@@ -970,6 +1027,9 @@ check_and_convert_grammar (void)
 
   /* Report any undefined symbols and consider them nonterminals.  */
   symbols_check_defined ();
+
+  if(rrebnf_flag) print_rrebnf();
+  if(naked_flag) print_naked_rules();
 
   if (SYMBOL_NUMBER_MAXIMUM - nnterms < ntokens)
     complain (NULL, fatal, "too many symbols in input grammar (limit is %d)",


### PR DESCRIPTION
Add two new options to output the naked grammar and an EBNF to view railroad diagram at https://www.bottlecaps.de/rr/ui

Copy and paste the EBNF bellow on https://www.bottlecaps.de/rr/ui tab Edit Grammar then switch to the tab View Diagram.
```
bison -e examples/c/calc/calc.y

input ::=
	/* empty */
	| input line 

line ::=
	'\n' 
	| expr '\n' 
	| error '\n' 

expr ::=
	expr '+' term 
	| expr '-' term 
	| term 

term ::=
	term '*' fact 
	| term '/' fact 
	| fact 

fact ::=
	"number" 
	| '(' expr ')'

```
```
bison -n examples/c/calc/calc.y
input :
	/* empty */
	| input line 
	;

line :
	'\n' 
	| expr '\n' 
	| error '\n' 
	;

expr :
	expr '+' term 
	| expr '-' term 
	| term 
	;

term :
	term '*' fact 
	| term '/' fact 
	| fact 
	;

fact :
	"number" 
	| '(' expr ')' 
	;
```
