### PR TITLE
question: is a long line still a problem in current bison version?

### DIFF
--- a/data/skeletons/variant.hh
+++ b/data/skeletons/variant.hh
@@ -401,7 +401,15 @@ m4_define([_b4_token_constructor_define],
                               b4_symbol_if([$1], [has_type], [std::move (v)]),
                               b4_locations_if([std::move (l)]))[)
       {
-        YYASSERT (]m4_join([ || ], m4_map_sep([_b4_type_clause], [, ], [$@]))[);
+        bool _inlist = false;
+        if( ]m4_join([ ) {
+          _inlist = true;
+        }
+        if ( ], m4_map_sep([_b4_type_clause], [, ], [$@]))[ ) {
+          _inlist = true;
+        }
+
+        YYASSERT (_inlist);
       }
 #else
       symbol_type (]b4_join(
@@ -413,7 +421,15 @@ m4_define([_b4_token_constructor_define],
                               b4_symbol_if([$1], [has_type], [v]),
                               b4_locations_if([l]))[)
       {
-        YYASSERT (]m4_join([ || ], m4_map_sep([_b4_type_clause], [, ], [$@]))[);
+        bool _inlist = false;
+        if( ]m4_join([ ) {
+          _inlist = true;
+        }
+        if ( ], m4_map_sep([_b4_type_clause], [, ], [$@]))[ ) {
+          _inlist = true;
+        }
+
+        YYASSERT (_inlist);
       }
 #endif
 ]])])


### PR DESCRIPTION
if you have a grammar with many tokens, it can happen that a line gets longer than 16k-bytes.
this is a problem on some compilers, but could get fixed with this "hack".

old output c++ output:
`YYASSERT (tok == token::sym1 || tok == token::sym2 || ...) // and many more`

new output c++ output:
```
bool _inlist = false;
if ( tok == token::sym1 ) {
  _inlist = true;
}
if ( tok == token::sym2 ) {
  _inlist = true;
}
... // and many more
YYASSERT (_inlist);
```

maybe this could get even nicer if using a switch instead of that if...